### PR TITLE
Find and display the shortest import cycle

### DIFF
--- a/src/Review/Project/Internal.elm
+++ b/src/Review/Project/Internal.elm
@@ -109,7 +109,17 @@ buildModuleGraph mods =
                         let
                             ( moduleNode, modulesEdges ) =
                                 nodesAndEdges
-                                    (\moduleName -> Dict.get moduleName moduleIds)
+                                    (\moduleName ->
+                                        if getModuleName module_ == [ "NoUnused", "VariablesTest" ] then
+                                            let
+                                                _ =
+                                                    Debug.log "imports" ( moduleName, Dict.get moduleName moduleIds )
+                                            in
+                                            Dict.get moduleName moduleIds
+
+                                        else
+                                            Dict.get moduleName moduleIds
+                                    )
                                     module_
                                     (getModuleId <| getModuleName module_)
                         in

--- a/src/Review/Project/Internal.elm
+++ b/src/Review/Project/Internal.elm
@@ -111,10 +111,6 @@ buildModuleGraph mods =
                                 nodesAndEdges
                                     (\moduleName ->
                                         if getModuleName module_ == [ "NoUnused", "VariablesTest" ] then
-                                            let
-                                                _ =
-                                                    Debug.log "imports" ( moduleName, Dict.get moduleName moduleIds )
-                                            in
                                             Dict.get moduleName moduleIds
 
                                         else

--- a/src/Review/Project/Internal.elm
+++ b/src/Review/Project/Internal.elm
@@ -109,13 +109,7 @@ buildModuleGraph mods =
                         let
                             ( moduleNode, modulesEdges ) =
                                 nodesAndEdges
-                                    (\moduleName ->
-                                        if getModuleName module_ == [ "NoUnused", "VariablesTest" ] then
-                                            Dict.get moduleName moduleIds
-
-                                        else
-                                            Dict.get moduleName moduleIds
-                                    )
+                                    (\moduleName -> Dict.get moduleName moduleIds)
                                     module_
                                     (getModuleId <| getModuleName module_)
                         in

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -613,7 +613,7 @@ visitorDiscoverCycle targetNode path distance acc =
         if distance == 0 then
             case List.head path of
                 Just head ->
-                    if IntDict.member head.node.id head.outgoing then
+                    if IntDict.member head.node.id (Debug.log "incoming" head.incoming) then
                         acc
 
                     else

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -560,7 +560,6 @@ findCycle graph edge =
         initialCycle =
             Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle edge.to) [ edge.from ] [] graph
                 |> Tuple.first
-                |> Debug.log "initial"
     in
     findSmallerCycle graph initialCycle initialCycle
         |> List.map .label
@@ -578,7 +577,6 @@ findSmallerCycle graph currentBest nodesToVisit =
                 cycle =
                     Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle startingNode.id) [ startingNode.id ] [] graph
                         |> Tuple.first
-                        |> Debug.log ("for: " ++ Debug.toString startingNode)
 
                 newBest : List (Graph.Node n)
                 newBest =
@@ -602,18 +600,12 @@ reachedTarget targetNode path =
 
 visitorDiscoverCycle : Graph.NodeId -> List (Graph.NodeContext n e) -> Int -> List (Graph.Node n) -> List (Graph.Node n)
 visitorDiscoverCycle targetNode path distance acc =
-    let
-        _ =
-            Debug.log "distance" distance
-
-        _ =
-            Debug.log "path" (Maybe.map (.node >> .label) (List.head path))
-    in
     if List.isEmpty acc then
+        -- We haven't found the cycle yet
         if distance == 0 then
             case List.head path of
                 Just head ->
-                    if IntDict.member head.node.id (Debug.log "incoming" head.incoming) then
+                    if IntDict.member head.node.id head.incoming then
                         [ head.node ]
 
                     else
@@ -622,18 +614,14 @@ visitorDiscoverCycle targetNode path distance acc =
                 Nothing ->
                     acc
 
-        else
-        -- we haven't found the cycle yet
-        if
-            reachedTarget targetNode path
-        then
+        else if reachedTarget targetNode path then
             List.map .node path
 
         else
             []
 
     else
-        -- we already found the cycle
+        -- We already found the cycle
         acc
 
 

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -560,11 +560,11 @@ findCycle graph edge =
             Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle edge.to) [ edge.from ] [] graph
                 |> Tuple.first
     in
-    findSmallerCycle graph initialCycle edge.from initialCycle
+    findSmallerCycle graph initialCycle initialCycle
         |> List.map .label
 
 
-findSmallerCycle graph currentBest targetNode nodesToVisit =
+findSmallerCycle graph currentBest nodesToVisit =
     case nodesToVisit of
         [] ->
             currentBest
@@ -572,7 +572,7 @@ findSmallerCycle graph currentBest targetNode nodesToVisit =
         startingNode :: restOfNodes ->
             let
                 cycle =
-                    Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle targetNode) [ startingNode.id ] [] graph
+                    Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle startingNode.id) [ startingNode.id ] [] graph
                         |> Tuple.first
 
                 newBest =
@@ -582,7 +582,7 @@ findSmallerCycle graph currentBest targetNode nodesToVisit =
                     else
                         currentBest
             in
-            findSmallerCycle graph newBest startingNode.id restOfNodes
+            findSmallerCycle graph newBest restOfNodes
 
 
 reachedTarget : a -> List { b | node : { c | id : a } } -> Bool

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -614,7 +614,7 @@ visitorDiscoverCycle targetNode path distance acc =
             case List.head path of
                 Just head ->
                     if IntDict.member head.node.id (Debug.log "incoming" head.incoming) then
-                        acc
+                        [ head.node ]
 
                     else
                         acc

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -610,8 +610,23 @@ visitorDiscoverCycle targetNode path distance acc =
             Debug.log "path" (Maybe.map (.node >> .label) (List.head path))
     in
     if List.isEmpty acc then
+        if distance == 0 then
+            case List.head path of
+                Just head ->
+                    if IntDict.member head.node.id head.outgoing then
+                        acc
+
+                    else
+                        acc
+
+                Nothing ->
+                    acc
+
+        else
         -- we haven't found the cycle yet
-        if reachedTarget targetNode path then
+        if
+            reachedTarget targetNode path
+        then
             List.map .node path
 
         else

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -584,7 +584,11 @@ findSmallerCycle graph currentBest nodesToVisit =
                     else
                         currentBest
             in
-            findSmallerCycle graph newBest restOfNodes
+            if List.length newBest == 1 then
+                newBest
+
+            else
+                findSmallerCycle graph newBest restOfNodes
 
 
 reachedTarget : a -> List { b | node : { c | id : a } } -> Bool

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -559,6 +559,7 @@ findCycle graph edge =
         initialCycle =
             Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle edge.to) [ edge.from ] [] graph
                 |> Tuple.first
+                |> Debug.log "initial"
     in
     findSmallerCycle graph initialCycle initialCycle
         |> List.map .label
@@ -574,6 +575,7 @@ findSmallerCycle graph currentBest nodesToVisit =
                 cycle =
                     Graph.guidedBfs Graph.alongIncomingEdges (visitorDiscoverCycle startingNode.id) [ startingNode.id ] [] graph
                         |> Tuple.first
+                        |> Debug.log ("for: " ++ Debug.toString startingNode)
 
                 newBest =
                     if List.length cycle > 0 && List.length cycle < List.length currentBest then
@@ -590,8 +592,15 @@ reachedTarget targetNode path =
     Maybe.map (.node >> .id) (List.head path) == Just targetNode
 
 
-visitorDiscoverCycle : a -> List { b | node : { c | id : a } } -> d -> List { c | id : a } -> List { c | id : a }
-visitorDiscoverCycle targetNode path _ acc =
+visitorDiscoverCycle : a -> List { b | node : { c | id : a, label : e } } -> Int -> List { c | id : a, label : e } -> List { c | id : a, label : e }
+visitorDiscoverCycle targetNode path distance acc =
+    let
+        _ =
+            Debug.log "distance" distance
+
+        _ =
+            Debug.log "path" (Maybe.map (.node >> .label) (List.head path))
+    in
     if List.isEmpty acc then
         -- we haven't found the cycle yet
         if reachedTarget targetNode path then


### PR DESCRIPTION
How it works:
- We try to get the get the topologicalSort of the module list, which fails if there is a cycle
- When we detect a cycle, we only have the problematic edge. We do a cycle search starting from that edge
- Before: We would report the found cycle
- After: For every module in that cycle, we do a new cycle search and we take the shortest one out of all of those, which we then report
