### PR TITLE
correct explicitly spelling

### DIFF
--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -4535,7 +4535,7 @@ withModuleNameLookupTable (ContextCreator fn (RequestedData requested)) =
         (RequestedData { requested | moduleNameLookupTable = True })
 
 
-{-| Request the [module key](ModuleKey) for this module.
+{-| Request the [module key](#ModuleKey) for this module.
 
     rule =
         Rule.newProjectRuleSchema "NoMissingSubscriptionsCall" initialProjectContext

--- a/src/Review/Test.elm
+++ b/src/Review/Test.elm
@@ -63,7 +63,7 @@ A good test title explains
   - what is tested - Probably the rule, but making it explicit
     in a [`describe`](https://package.elm-lang.org/packages/elm-explorations/test/latest/Test#describe)
     might improve your test report. Or maybe you are testing a sub-part of the rule,
-    and you can name it explictly.
+    and you can name it explicitly.
   - what should happen: (not) reporting an error, fix <something> by <doing something>, ...
   - when: what is the situation that this test sets up?
 


### PR DESCRIPTION
Mini spelling correction in `Review.Test`'s file comment:
```
- explictly
+ explicitly
```
That isn't really worth a PR so here's another thing I noticed when running the new [elm-review-links-point-to-existing-package-members](https://package.elm-lang.org/packages/lue-bird/elm-review-links-point-to-existing-package-members/1.0.2/):
- There's the link to `(#moduleGraph)` in the `Review-Project.precomputeModuleGraph` doc but this function is only exposed from `Review.Project.Internal`.
- There's the link to `(#error)` in the `Review.Test.FailureMessage` doc which doesn't expose such a function. It should probably point to `Review-Test#error`
- There's the link `(ModuleKey)` in the `Rule.withModuleKey` doc which doesn't work because it is interpreted as a _module_.  The PR corrects it to `#ModuleKey`