### PR TITLE
Prevent unnecessary visits

### DIFF
--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -4713,23 +4713,8 @@ expressionChildren node =
         Expression.Application expressions ->
             expressions
 
-        Expression.Literal _ ->
-            []
-
-        Expression.Integer _ ->
-            []
-
-        Expression.Floatable _ ->
-            []
-
-        Expression.UnitExpr ->
-            []
-
         Expression.ListExpr elements ->
             elements
-
-        Expression.FunctionOrValue _ _ ->
-            []
 
         Expression.RecordExpr fields ->
             List.map (Node.value >> (\( _, expr ) -> expr)) fields
@@ -4739,9 +4724,6 @@ expressionChildren node =
 
         Expression.ParenthesizedExpression expr ->
             [ expr ]
-
-        Expression.Operator _ ->
-            []
 
         Expression.OperatorApplication _ direction left right ->
             case direction of
@@ -4780,25 +4762,13 @@ expressionChildren node =
         Expression.TupledExpression expressions ->
             expressions
 
-        Expression.PrefixOperator _ ->
-            []
-
-        Expression.Hex _ ->
-            []
-
         Expression.Negation expr ->
             [ expr ]
-
-        Expression.CharLiteral _ ->
-            []
 
         Expression.RecordAccess expr _ ->
             [ expr ]
 
-        Expression.RecordAccessFunction _ ->
-            []
-
-        Expression.GLSLExpression _ ->
+        _ ->
             []
 
 


### PR DESCRIPTION
This PR makes it so that we don't visit parts of the AST when there are no visitors for them.

For instance:
1. If there are no declaration nor expression visitors, then we don't visit them at all
2. If you only visit expressions on enter, then we can use a faster AST "traverser" to apply the provided visitor function.

While 1. seems to be making quite a bit of difference for rules like `NoUnused.Modules`, 2. doesn't seem to be making much difference in practice, which makes me sad. "This was not the bottleneck you were looking for".