### PR TITLE
Fix flipped error message

### DIFF
--- a/src/Review/Test/FailureMessage.elm
+++ b/src/Review/Test/FailureMessage.elm
@@ -195,11 +195,11 @@ unexpectedGlobalErrorDetails expectedDetails error =
 
 and I was expecting its details to be:
 
-  """ ++ formatDetails error.details ++ """
+  """ ++ formatDetails expectedDetails ++ """
 
 but I found these details:
 
-  """ ++ formatDetails expectedDetails)
+  """ ++ formatDetails error.details)
 
 
 unexpectedConfigurationErrorDetails : List String -> { message : String, details : List String } -> String
@@ -211,11 +211,11 @@ unexpectedConfigurationErrorDetails expectedDetails error =
 
 and I was expecting its details to be:
 
-  """ ++ formatDetails error.details ++ """
+  """ ++ formatDetails expectedDetails ++ """
 
 but I found these details:
 
-  """ ++ formatDetails expectedDetails)
+  """ ++ formatDetails error.details)
 
 
 emptyDetails : String -> String

--- a/tests/Review/Test/FailureMessageTest.elm
+++ b/tests/Review/Test/FailureMessageTest.elm
@@ -398,11 +398,11 @@ I found a global error with the following message:
 
 and I was expecting its details to be:
 
-  `Some other details`
+  `Some details`
 
 but I found these details:
 
-  `Some details`"""
+  `Some other details`"""
 
 
 unexpectedConfigurationErrorDetailsTest : Test
@@ -430,11 +430,11 @@ I found a configuration error with the following message:
 
 and I was expecting its details to be:
 
-  `Some other details`
+  `Some details`
 
 but I found these details:
 
-  `Some details`"""
+  `Some other details`"""
 
 
 emptyDetailsTest : Test


### PR DESCRIPTION
Error messages for `unexpectedGlobalErrorDetails` and `unexpectedConfigurationErrorDetails` had their expected and actual
details flipped, which made it quite confusing to figure out why tests were failing.  :laughing: 