### PR TITLE
Fix ModuleNameLookupTable resolving to indirect dependencies

### DIFF
--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -6143,12 +6143,12 @@ registerImportExposed import_ innerContext =
 
                 module_ : Elm.Docs.Module
                 module_ =
-                    (case Dict.get (joinModuleName moduleName) innerContext.dependenciesModules of
+                    (case Dict.get moduleName innerContext.modules of
                         Just m ->
                             Just m
 
                         Nothing ->
-                            Dict.get moduleName innerContext.modules
+                            Dict.get (joinModuleName moduleName) innerContext.dependenciesModules
                     )
                         |> Maybe.withDefault
                             { name = joinModuleName moduleName

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5554,6 +5554,7 @@ isInSourceDirectories (Metadata metadata) =
 scopeRule : RunnableProjectVisitor ScopeProjectContext ScopeModuleContext
 scopeRule =
     newProjectRuleSchema "elm-review__SCOPE" scope_initialProjectContext
+        |> withElmJsonProjectVisitor scope_elmJsonVisitor
         |> withContextFromImportedModules
         |> withDirectDependenciesProjectVisitor (scope_dependenciesVisitor |> scope_pairWithNoErrors)
         |> withModuleVisitor scope_moduleVisitor
@@ -5706,6 +5707,15 @@ scope_moduleVisitor schema =
 scope_pairWithNoErrors : (visited -> context -> context) -> visited -> context -> ( List nothing, context )
 scope_pairWithNoErrors fn visited context =
     ( [], fn visited context )
+
+
+
+-- elm.json
+
+
+scope_elmJsonVisitor : Maybe { a | project : Elm.Project.Project } -> ScopeProjectContext -> ( List nothing, ScopeProjectContext )
+scope_elmJsonVisitor maybeElmJson projectContext =
+    ( [], projectContext )
 
 
 

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5747,12 +5747,13 @@ scope_elmJsonVisitor maybeElmJson projectContext =
 -- DEPENDENCIES
 
 
-scope_dependenciesVisitor : Dict String Dependency -> { context | dependenciesModules : Dict String Elm.Docs.Module } -> { context | dependenciesModules : Dict String Elm.Docs.Module }
+scope_dependenciesVisitor : Dict String Dependency -> ScopeProjectContext -> ScopeProjectContext
 scope_dependenciesVisitor dependencies innerContext =
     let
         dependenciesModules : Dict String Elm.Docs.Module
         dependenciesModules =
             dependencies
+                |> Dict.filter (\key _ -> Set.member key innerContext.directDependencies)
                 |> Dict.values
                 |> ListExtra.fastConcatMap Review.Project.Dependency.modules
                 |> List.map (\dependencyModule -> ( dependencyModule.name, dependencyModule ))

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5568,7 +5568,8 @@ scopeRule =
 
 
 type alias ScopeProjectContext =
-    { dependenciesModules : Dict String Elm.Docs.Module
+    { directDependencies : Set String
+    , dependenciesModules : Dict String Elm.Docs.Module
     , modules : Dict ModuleName Elm.Docs.Module
     , lookupTables : Dict ModuleName ModuleNameLookupTable
     }
@@ -5598,7 +5599,8 @@ type alias ScopeModuleContext =
 
 scope_initialProjectContext : ScopeProjectContext
 scope_initialProjectContext =
-    { dependenciesModules = Dict.empty
+    { directDependencies = Set.empty
+    , dependenciesModules = Dict.empty
     , modules = Dict.empty
     , lookupTables = Dict.empty
     }
@@ -5637,7 +5639,8 @@ scope_fromProjectToModule _ moduleName projectContext =
 
 scope_fromModuleToProject : a -> Node ModuleName -> ScopeModuleContext -> ScopeProjectContext
 scope_fromModuleToProject _ moduleName moduleContext =
-    { dependenciesModules = Dict.empty
+    { directDependencies = Set.empty
+    , dependenciesModules = Dict.empty
     , modules =
         Dict.singleton (Node.value moduleName)
             { name = String.join "." (Node.value moduleName)
@@ -5653,7 +5656,8 @@ scope_fromModuleToProject _ moduleName moduleContext =
 
 scope_foldProjectContexts : ScopeProjectContext -> ScopeProjectContext -> ScopeProjectContext
 scope_foldProjectContexts newContext previousContext =
-    { dependenciesModules = previousContext.dependenciesModules
+    { directDependencies = previousContext.directDependencies
+    , dependenciesModules = previousContext.dependenciesModules
     , modules = Dict.union previousContext.modules newContext.modules
     , lookupTables = Dict.union newContext.lookupTables previousContext.lookupTables
     }

--- a/tests/ModuleNameLookupTableTest.elm
+++ b/tests/ModuleNameLookupTableTest.elm
@@ -509,12 +509,6 @@ project =
         |> Project.addDependency xyz2dependency
 
 
-application : Project
-application =
-    Project.new
-        |> Project.addElmJson applicationElmJson
-
-
 applicationElmJson : { path : String, raw : String, project : Elm.Project.Project }
 applicationElmJson =
     { path = "elm.json"

--- a/tests/ModuleNameLookupTableTest.elm
+++ b/tests/ModuleNameLookupTableTest.elm
@@ -1,5 +1,9 @@
 module ModuleNameLookupTableTest exposing (all)
 
+import Elm.Docs
+import Elm.License
+import Elm.Package
+import Elm.Project
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -7,12 +11,15 @@ import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern as Pattern
 import Elm.Syntax.Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
+import Elm.Version
 import Fixtures.Dependencies as Dependencies
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Project as Project exposing (Project)
+import Review.Project.Dependency as Dependency exposing (Dependency)
 import Review.Rule as Rule exposing (Rule)
 import Review.Test
 import Review.Test.Dependencies
+import Review.Test.Dependencies.Unsafe as Unsafe
 import Test exposing (Test, describe, test)
 
 
@@ -469,7 +476,7 @@ a = value
 """, """module Element exposing (value)
 value = 1
 """ ]
-                    |> Review.Test.runOnModulesWithProjectData projectWithIndirectDependencies rule
+                    |> Review.Test.runOnModulesWithProjectData project rule
                     |> Review.Test.expectErrorsForModules
                         [ ( "A"
                           , [ Review.Test.error
@@ -494,16 +501,106 @@ type alias ModuleContext =
 project : Project
 project =
     Project.new
+        |> Project.addElmJson applicationElmJson
         |> Project.addDependency Dependencies.elmCore
         |> Project.addDependency Dependencies.elmHtml
         |> Project.addDependency Review.Test.Dependencies.elmParser
         |> Project.addDependency Review.Test.Dependencies.elmUrl
+        |> Project.addDependency xyz2dependency
 
 
-projectWithIndirectDependencies : Project
-projectWithIndirectDependencies =
+application : Project
+application =
     Project.new
-        |> Project.addDependency Dependencies.elmCore
+        |> Project.addElmJson applicationElmJson
+
+
+applicationElmJson : { path : String, raw : String, project : Elm.Project.Project }
+applicationElmJson =
+    { path = "elm.json"
+    , raw = """{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.0",
+            "elm/html": "1.0.0",
+            "elm/parser": "1.0.0",
+            "elm/url": "1.0.0",
+            "abc/xyz": "1.0.0"
+        },
+        "indirect": {
+            "abc/xyz2": "1.0.0"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}"""
+    , project =
+        Elm.Project.Application
+            { elm = Elm.Version.one
+            , dirs = []
+            , depsDirect =
+                [ ( unsafePackageName "elm/core", Elm.Version.one )
+                , ( unsafePackageName "elm/html", Elm.Version.one )
+                , ( unsafePackageName "elm/parser", Elm.Version.one )
+                , ( unsafePackageName "elm/url", Elm.Version.one )
+                , ( unsafePackageName "abc/xyz", Elm.Version.one )
+                ]
+            , depsIndirect = [ ( unsafePackageName "abc/xyz2", Elm.Version.one ) ]
+            , testDepsDirect = []
+            , testDepsIndirect = []
+            }
+    }
+
+
+xyz2dependency : Dependency
+xyz2dependency =
+    Dependency.create "abc/xyz2"
+        xyz2elmJson
+        xyz2dependencyModules
+
+
+xyz2elmJson : Elm.Project.Project
+xyz2elmJson =
+    Elm.Project.Package
+        { elm = Unsafe.constraint "0.19.0 <= v < 0.20.0"
+        , exposed = Elm.Project.ExposedList [ Unsafe.moduleName "Element" ]
+        , license = Elm.License.fromString "BSD-3-Clause" |> Maybe.withDefault Elm.License.bsd3
+        , name = Unsafe.packageName "elm/xyz"
+        , summary = "Fake stuff"
+        , deps = [ ( Unsafe.packageName "elm/core", Unsafe.constraint "1.0.0 <= v < 2.0.0" ) ]
+        , testDeps = []
+        , version = Elm.Version.fromString "1.0.0" |> Maybe.withDefault Elm.Version.one
+        }
+
+
+xyz2dependencyModules : List Elm.Docs.Module
+xyz2dependencyModules =
+    [ { name = "Element"
+      , comment = ""
+      , unions = []
+      , aliases = []
+      , values = []
+      , binops = []
+      }
+    ]
+
+
+unsafePackageName : String -> Elm.Package.Name
+unsafePackageName packageName =
+    case Elm.Package.fromString packageName of
+        Just name ->
+            name
+
+        Nothing ->
+            -- unsafe, but if the generation went well, it should all be good.
+            unsafePackageName packageName
 
 
 createRule : (Rule.ModuleRuleSchema {} ModuleContext -> Rule.ModuleRuleSchema { hasAtLeastOneVisitor : () } ModuleContext) -> Rule


### PR DESCRIPTION
Fixes #134

This makes sure that the module name lookup table doesn't look at modules from indirect dependencies.

@hanshenrik could you try the fix out? You can do that by cloning this repo, checking out this branch (`issue-134`) and then running the following command:

```bash
LOCAL_ELM_REVIEW_SRC=<path-to-elm-review>/src elm-review --config <path-to-elm-review>/review --rules NoUnused.Variables --ignore-dirs "lib"
```

Don't forget to replace the paths. And you might get some errors for things that you've ignored. 