### PR TITLE
Feature: Extract data from the project

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,7 +11,8 @@
         "Review.Project.Dependency",
         "Review.Fix",
         "Review.Test",
-        "Review.Test.Dependencies"
+        "Review.Test.Dependencies",
+        "Review.Options"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -1,4 +1,4 @@
-module Ansi exposing (backgroundRed, bold, cyan, red, yellow)
+module Ansi exposing (backgroundRed, bold, cyan, green, red, yellow)
 
 -- FONTS
 
@@ -20,6 +20,11 @@ applyColor color string =
 red : String -> String
 red =
     applyColor "31"
+
+
+green : String -> String
+green =
+    applyColor "32"
 
 
 yellow : String -> String

--- a/src/Review/Error.elm
+++ b/src/Review/Error.elm
@@ -1,4 +1,4 @@
-module Review.Error exposing (Fix(..), InternalError, ReviewError(..), Target(..), error, withFixes)
+module Review.Error exposing (Fix(..), InternalError, ReviewError(..), Target(..), doesPreventExtract, error, preventExtract, withFixes)
 
 import Elm.Syntax.Range exposing (Range)
 
@@ -23,6 +23,7 @@ type alias InternalError =
     , range : Range
     , fixes : Maybe (List Fix)
     , target : Target
+    , preventsExtract : Bool
     }
 
 
@@ -45,6 +46,7 @@ error { message, details } range =
         , range = range
         , fixes = Nothing
         , target = Module
+        , preventsExtract = False
         }
 
 
@@ -59,3 +61,13 @@ withFixes fixes (ReviewError error_) =
                 else
                     Just fixes
         }
+
+
+preventExtract : InternalError -> InternalError
+preventExtract error_ =
+    { error_ | preventsExtract = True }
+
+
+doesPreventExtract : InternalError -> Bool
+doesPreventExtract error_ =
+    error_.preventsExtract

--- a/src/Review/Options.elm
+++ b/src/Review/Options.elm
@@ -1,0 +1,43 @@
+module Review.Options exposing
+    ( ReviewOptions
+    , defaults
+    , withDataExtraction
+    )
+
+{-| Configure how `elm-review` runs.
+
+You should not have to use this when writing a rule. This is only necessary if you wish to run `elm-review` in a new
+process like the CLI.
+
+@docs ReviewOptions
+@docs defaults
+@docs withDataExtraction
+
+-}
+
+import Review.Options.Internal exposing (ReviewOptionsInternal(..))
+
+
+{-| Represents the different options you can use to run the review process.
+-}
+type alias ReviewOptions =
+    ReviewOptionsInternal
+
+
+{-| Somewhat arbitrary default options.
+
+  - Does not enable data extraction
+
+-}
+defaults : ReviewOptions
+defaults =
+    ReviewOptionsInternal
+        { extract = False
+        }
+
+
+{-| Enable or disable data extraction.
+-}
+withDataExtraction : Bool -> ReviewOptions -> ReviewOptions
+withDataExtraction extract (ReviewOptionsInternal reviewOptions) =
+    ReviewOptionsInternal { reviewOptions | extract = extract }

--- a/src/Review/Options/Internal.elm
+++ b/src/Review/Options/Internal.elm
@@ -1,0 +1,7 @@
+module Review.Options.Internal exposing (ReviewOptionsInternal(..))
+
+
+type ReviewOptionsInternal
+    = ReviewOptionsInternal
+        { extract : Bool
+        }

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -320,7 +320,7 @@ type Rule
         { name : String
         , exceptions : Exceptions
         , requestedData : RequestedData
-        , ruleImplementation : Exceptions -> Project -> List (Graph.NodeContext ModuleName ()) -> ( List (Error {}), Rule )
+        , ruleImplementation : Exceptions -> Project -> List (Graph.NodeContext ModuleName ()) -> { errors : List (Error {}), rule : Rule, extract : Maybe Extract }
         , configurationError : Maybe { message : String, details : List String }
         }
 
@@ -894,14 +894,24 @@ runRules :
     -> { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
 runRules initialRules project nodeContexts =
     List.foldl
-        (\(Rule { exceptions, ruleImplementation }) { errors, rules, extracts } ->
+        (\(Rule { name, exceptions, ruleImplementation }) { errors, rules, extracts } ->
             let
-                ( ruleErrors, ruleWithCache ) =
+                result : { errors : List (Error {}), rule : Rule, extract : Maybe Extract }
+                result =
                     ruleImplementation exceptions project nodeContexts
             in
-            { errors = ListExtra.orderIndependentMapAppend removeErrorPhantomType ruleErrors errors
-            , rules = ruleWithCache :: rules
-            , extracts = extracts
+            { errors = ListExtra.orderIndependentMapAppend removeErrorPhantomType result.errors errors
+            , rules = result.rule :: rules
+            , extracts =
+                case result.extract of
+                    Just (JsonExtract extract) ->
+                        Dict.insert name extract extracts
+
+                    Just (ModuleNameLookupTableExtract _) ->
+                        extracts
+
+                    Nothing ->
+                        extracts
             }
         )
         { errors = []
@@ -1331,7 +1341,10 @@ fromProjectRuleSchema ((ProjectRuleSchema schema) as projectRuleSchema) =
                             project
                             nodeContexts
                 in
-                ( result.errors, result.rule )
+                { errors = result.errors
+                , rule = result.rule
+                , extract = result.extract
+                }
         , configurationError = Nothing
         }
 
@@ -1598,7 +1611,7 @@ configurationError name configurationError_ =
         { name = name
         , exceptions = Exceptions.init
         , requestedData = RequestedData { moduleNameLookupTable = False, sourceCodeExtractor = False }
-        , ruleImplementation = \_ _ _ -> ( [], configurationError name configurationError_ )
+        , ruleImplementation = \_ _ _ -> { errors = [], rule = configurationError name configurationError_, extract = Nothing }
         , configurationError = Just configurationError_
         }
 
@@ -4248,7 +4261,10 @@ runProjectVisitor projectVisitor maybePreviousCache exceptions project nodeConte
                                 newProject
                                 newNodeContexts
                     in
-                    ( result.errors, result.rule )
+                    { errors = result.errors
+                    , rule = result.rule
+                    , extract = result.extract
+                    }
             , configurationError = Nothing
             }
     , cache = newCache

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -455,7 +455,7 @@ review rules project =
 
                                 moduleNameLookupTables : Maybe (Dict ModuleName ModuleNameLookupTable)
                                 moduleNameLookupTables =
-                                    Maybe.map (\(Extract moduleNameLookupTables_) -> moduleNameLookupTables_) scopeResult.extract
+                                    Maybe.map (\(ModuleNameLookupTableExtract moduleNameLookupTables_) -> moduleNameLookupTables_) scopeResult.extract
 
                                 projectWithLookupTable : Project
                                 projectWithLookupTable =
@@ -591,7 +591,7 @@ runReview ((Project p) as project) rules maybeProjectData nodeContexts =
 
         moduleNameLookupTables : Maybe (Dict ModuleName ModuleNameLookupTable)
         moduleNameLookupTables =
-            Maybe.map (\(Extract moduleNameLookupTables_) -> moduleNameLookupTables_) scopeResult.extract
+            Maybe.map (\(ModuleNameLookupTableExtract moduleNameLookupTables_) -> moduleNameLookupTables_) scopeResult.extract
 
         projectWithLookupTables : Project
         projectWithLookupTables =
@@ -1925,7 +1925,7 @@ withFinalProjectEvaluation visitor (ProjectRuleSchema schema) =
 
 
 type Extract
-    = Extract (Dict ModuleName ModuleNameLookupTable)
+    = ModuleNameLookupTableExtract (Dict ModuleName ModuleNameLookupTable)
 
 
 withDataExtractor :
@@ -5595,7 +5595,7 @@ scopeRule =
             , fromModuleToProject = scope_fromModuleToProject
             , foldProjectContexts = scope_foldProjectContexts
             }
-        |> withDataExtractor (\projectContext -> Extract projectContext.lookupTables)
+        |> withDataExtractor (\projectContext -> ModuleNameLookupTableExtract projectContext.lookupTables)
         |> fromProjectRuleSchemaToRunnableProjectVisitor
 
 

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -544,7 +544,7 @@ reviewV2 rules maybeProjectData project =
     of
         Ok nodeContexts ->
             let
-                runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+                runResult : { errors : List ReviewError, rules : List Rule, project : Project, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
                 runResult =
                     runReview ReviewOptions.defaults project rules maybeProjectData nodeContexts
             in
@@ -600,7 +600,7 @@ exported/imported with `elm/browser`'s debugger, and may cause a crash if you tr
 to compare them or the model that holds them.
 
 -}
-reviewV3 : ReviewOptions -> List Rule -> Maybe ProjectData -> Project -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+reviewV3 : ReviewOptions -> List Rule -> Maybe ProjectData -> Project -> { errors : List ReviewError, rules : List Rule, project : Project, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
 reviewV3 reviewOptions rules maybeProjectData project =
     case
         checkForConfigurationErrors rules
@@ -614,6 +614,7 @@ reviewV3 reviewOptions rules maybeProjectData project =
         Err errors ->
             { errors = errors
             , rules = rules
+            , project = project
             , projectData = maybeProjectData
             , extracts = Dict.empty
             }
@@ -800,7 +801,7 @@ wrapInCycle string =
     "    ┌─────┐\n    │    " ++ string ++ "\n    └─────┘"
 
 
-runReview : ReviewOptions -> Project -> List Rule -> Maybe ProjectData -> List (Graph.NodeContext ModuleName ()) -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+runReview : ReviewOptions -> Project -> List Rule -> Maybe ProjectData -> List (Graph.NodeContext ModuleName ()) -> { errors : List ReviewError, rules : List Rule, project : Project, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
 runReview reviewOptions ((Project p) as project) rules maybeProjectData nodeContexts =
     let
         scopeResult : { projectData : Maybe ProjectData, lookupTables : Maybe (Dict ModuleName ModuleNameLookupTable) }
@@ -845,6 +846,7 @@ runReview reviewOptions ((Project p) as project) rules maybeProjectData nodeCont
     in
     { errors = ListExtra.orderIndependentMap errorToReviewError runResult.errors
     , rules = runResult.rules
+    , project = project
     , projectData = scopeResult.projectData
     , extracts = runResult.extracts
     }

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -326,7 +326,7 @@ type Rule
         { name : String
         , exceptions : Exceptions
         , requestedData : RequestedData
-        , ruleImplementation : Exceptions -> Project -> List (Graph.NodeContext ModuleName ()) -> { errors : List (Error {}), rule : Rule, extract : Maybe Extract }
+        , ruleImplementation : ReviewV3Options -> Exceptions -> Project -> List (Graph.NodeContext ModuleName ()) -> { errors : List (Error {}), rule : Rule, extract : Maybe Extract }
         , configurationError : Maybe { message : String, details : List String }
         }
 
@@ -453,6 +453,7 @@ review rules ((Project p) as project) =
                                     }
                                 scopeResult =
                                     runProjectVisitor
+                                        { extract = True }
                                         scopeRule
                                         Nothing
                                         Exceptions.init
@@ -482,7 +483,7 @@ review rules ((Project p) as project) =
                                 let
                                     runRulesResult : { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
                                     runRulesResult =
-                                        runRules rules projectWithLookupTable sortedModules
+                                        runRules { extract = False } rules projectWithLookupTable sortedModules
                                 in
                                 ( ListExtra.orderIndependentMap errorToReviewError runRulesResult.errors, runRulesResult.rules )
 
@@ -542,7 +543,7 @@ reviewV2 rules maybeProjectData project =
             let
                 runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
                 runResult =
-                    runReview project rules maybeProjectData nodeContexts
+                    runReview { extract = False } project rules maybeProjectData nodeContexts
             in
             { errors = runResult.errors
             , rules = runResult.rules
@@ -596,8 +597,8 @@ exported/imported with `elm/browser`'s debugger, and may cause a crash if you tr
 to compare them or the model that holds them.
 
 -}
-reviewV3 : List Rule -> Maybe ProjectData -> Project -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
-reviewV3 rules maybeProjectData project =
+reviewV3 : ReviewV3Options -> List Rule -> Maybe ProjectData -> Project -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+reviewV3 reviewOptions rules maybeProjectData project =
     case
         checkForConfigurationErrors rules
             |> Result.andThen (\() -> checkForModulesThatFailedToParse project)
@@ -605,7 +606,7 @@ reviewV3 rules maybeProjectData project =
             |> Result.andThen (\() -> getModulesSortedByImport project)
     of
         Ok nodeContexts ->
-            runReview project rules maybeProjectData nodeContexts
+            runReview reviewOptions project rules maybeProjectData nodeContexts
 
         Err errors ->
             { errors = errors
@@ -613,6 +614,11 @@ reviewV3 rules maybeProjectData project =
             , projectData = maybeProjectData
             , extracts = Dict.empty
             }
+
+
+type alias ReviewV3Options =
+    { extract : Bool
+    }
 
 
 checkForConfigurationErrors : List Rule -> Result (List ReviewError) ()
@@ -795,8 +801,8 @@ wrapInCycle string =
     "    ┌─────┐\n    │    " ++ string ++ "\n    └─────┘"
 
 
-runReview : Project -> List Rule -> Maybe ProjectData -> List (Graph.NodeContext ModuleName ()) -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
-runReview ((Project p) as project) rules maybeProjectData nodeContexts =
+runReview : ReviewV3Options -> Project -> List Rule -> Maybe ProjectData -> List (Graph.NodeContext ModuleName ()) -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+runReview reviewOptions ((Project p) as project) rules maybeProjectData nodeContexts =
     let
         scopeResult : { projectData : Maybe ProjectData, lookupTables : Maybe (Dict ModuleName ModuleNameLookupTable) }
         scopeResult =
@@ -804,6 +810,7 @@ runReview ((Project p) as project) rules maybeProjectData nodeContexts =
                 let
                     { cache, extract } =
                         runProjectVisitor
+                            { extract = True }
                             scopeRule
                             (Maybe.map extractProjectData maybeProjectData)
                             Exceptions.init
@@ -835,7 +842,7 @@ runReview ((Project p) as project) rules maybeProjectData nodeContexts =
     let
         runResult : { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
         runResult =
-            runRules rules projectWithLookupTables nodeContexts
+            runRules reviewOptions rules projectWithLookupTables nodeContexts
     in
     { errors = ListExtra.orderIndependentMap errorToReviewError runResult.errors
     , rules = runResult.rules
@@ -894,17 +901,18 @@ duplicateModulesGlobalError duplicate =
 
 
 runRules :
-    List Rule
+    ReviewV3Options
+    -> List Rule
     -> Project
     -> List (Graph.NodeContext ModuleName ())
     -> { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
-runRules initialRules project nodeContexts =
+runRules reviewOptions initialRules project nodeContexts =
     List.foldl
         (\(Rule { name, exceptions, ruleImplementation }) { errors, rules, extracts } ->
             let
                 result : { errors : List (Error {}), rule : Rule, extract : Maybe Extract }
                 result =
-                    ruleImplementation exceptions project nodeContexts
+                    ruleImplementation reviewOptions exceptions project nodeContexts
             in
             { errors = ListExtra.orderIndependentMapAppend removeErrorPhantomType result.errors errors
             , rules = result.rule :: rules
@@ -1336,11 +1344,12 @@ fromProjectRuleSchema ((ProjectRuleSchema schema) as projectRuleSchema) =
                 Nothing ->
                     RequestedData { moduleNameLookupTable = False, sourceCodeExtractor = False }
         , ruleImplementation =
-            \exceptions project nodeContexts ->
+            \reviewOptions exceptions project nodeContexts ->
                 let
                     result : { errors : List (Error {}), rule : Rule, cache : ProjectRuleCache projectContext, extract : Maybe Extract }
                     result =
                         runProjectVisitor
+                            reviewOptions
                             (fromProjectRuleSchemaToRunnableProjectVisitor projectRuleSchema)
                             Nothing
                             exceptions
@@ -1617,7 +1626,7 @@ configurationError name configurationError_ =
         { name = name
         , exceptions = Exceptions.init
         , requestedData = RequestedData { moduleNameLookupTable = False, sourceCodeExtractor = False }
-        , ruleImplementation = \_ _ _ -> { errors = [], rule = configurationError name configurationError_, extract = Nothing }
+        , ruleImplementation = \_ _ _ _ -> { errors = [], rule = configurationError name configurationError_, extract = Nothing }
         , configurationError = Just configurationError_
         }
 
@@ -4180,13 +4189,14 @@ type alias CacheEntryFor value projectContext =
 
 
 runProjectVisitor :
-    RunnableProjectVisitor projectContext moduleContext
+    ReviewV3Options
+    -> RunnableProjectVisitor projectContext moduleContext
     -> Maybe (ProjectRuleCache projectContext)
     -> Exceptions
     -> Project
     -> List (Graph.NodeContext ModuleName ())
     -> { errors : List (Error {}), rule : Rule, cache : ProjectRuleCache projectContext, extract : Maybe Extract }
-runProjectVisitor projectVisitor maybePreviousCache exceptions project nodeContexts =
+runProjectVisitor reviewOptions projectVisitor maybePreviousCache exceptions project nodeContexts =
     -- IGNORE TCO
     let
         ( cacheWithInitialContext, hasInitialContextChanged ) =
@@ -4245,7 +4255,11 @@ runProjectVisitor projectVisitor maybePreviousCache exceptions project nodeConte
                 maybePreviousCache
 
         ( extract, maybeFoldedContext2 ) =
-            computeExtract projectVisitor computeFoldedContext maybeFoldedContext
+            if reviewOptions.extract then
+                computeExtract projectVisitor computeFoldedContext maybeFoldedContext
+
+            else
+                ( Nothing, maybeFoldedContext )
 
         newCache : ProjectRuleCache projectContext
         newCache =
@@ -4264,11 +4278,12 @@ runProjectVisitor projectVisitor maybePreviousCache exceptions project nodeConte
             , exceptions = exceptions
             , requestedData = projectVisitor.requestedData
             , ruleImplementation =
-                \newExceptions newProject newNodeContexts ->
+                \newReviewOptions newExceptions newProject newNodeContexts ->
                     let
                         result : { errors : List (Error {}), rule : Rule, cache : ProjectRuleCache projectContext, extract : Maybe Extract }
                         result =
                             runProjectVisitor
+                                newReviewOptions
                                 projectVisitor
                                 (Just newCache)
                                 newExceptions

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -20,7 +20,7 @@ module Review.Rule exposing
     , globalError, configurationError
     , ReviewError, errorRuleName, errorMessage, errorDetails, errorRange, errorFixes, errorFilePath, errorTarget
     , ignoreErrorsForDirectories, ignoreErrorsForFiles, filterErrorsForFiles
-    , review, reviewV2, ProjectData, ruleName, getConfigurationError
+    , reviewV3, reviewV2, review, ProjectData, ruleName, getConfigurationError
     , Required, Forbidden
     )
 
@@ -265,7 +265,7 @@ reason or seemingly inappropriately.
 
 # Running rules
 
-@docs review, reviewV2, ProjectData, ruleName, getConfigurationError
+@docs reviewV3, reviewV2, review, ProjectData, ruleName, getConfigurationError
 
 
 # Internals
@@ -414,7 +414,7 @@ to compare them or the model that holds them.
 
 -}
 review : List Rule -> Project -> ( List ReviewError, List Rule )
-review rules project =
+review rules ((Project p) as project) =
     case Review.Project.modulesThatFailedToParse project of
         [] ->
             case Review.Project.modules project |> duplicateModuleNames Dict.empty of
@@ -467,18 +467,18 @@ review rules project =
 
                                 projectWithLookupTable : Project
                                 projectWithLookupTable =
-                                    let
-                                        (Project p) =
-                                            project
-                                    in
                                     Project { p | moduleNameLookupTables = moduleNameLookupTables }
                             in
                             if not (List.isEmpty scopeResult.errors) then
                                 ( ListExtra.orderIndependentMap errorToReviewError scopeResult.errors, rules )
 
                             else
-                                runRules rules projectWithLookupTable sortedModules
-                                    |> Tuple.mapFirst (ListExtra.orderIndependentMap errorToReviewError)
+                                let
+                                    runRulesResult : { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
+                                    runRulesResult =
+                                        runRules rules projectWithLookupTable sortedModules
+                                in
+                                ( ListExtra.orderIndependentMap errorToReviewError runRulesResult.errors, runRulesResult.rules )
 
         modulesThatFailedToParse ->
             ( ListExtra.orderIndependentMap parsingError modulesThatFailedToParse, rules )
@@ -533,12 +533,79 @@ reviewV2 rules maybeProjectData project =
             |> Result.andThen (\() -> getModulesSortedByImport project)
     of
         Ok nodeContexts ->
+            let
+                runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+                runResult =
+                    runReview project rules maybeProjectData nodeContexts
+            in
+            { errors = runResult.errors
+            , rules = runResult.rules
+            , projectData = runResult.projectData
+            }
+
+        Err errors ->
+            { errors = errors
+            , rules = rules
+            , projectData = maybeProjectData
+            }
+
+
+{-| Review a project and gives back the errors raised by the given rules.
+
+Note that you won't need to use this function when writing a rule. You should
+only need it if you try to make `elm-review` run in a new environment.
+
+    import Review.Project as Project exposing (Project)
+    import Review.Rule as Rule exposing (Rule)
+
+    config : List Rule
+    config =
+        [ Some.Rule.rule
+        , Some.Other.Rule.rule
+        ]
+
+    project : Project
+    project =
+        Project.new
+            |> Project.addModule { path = "src/A.elm", source = "module A exposing (a)\na = 1" }
+            |> Project.addModule { path = "src/B.elm", source = "module B exposing (b)\nb = 1" }
+
+    doReview =
+        let
+            { errors, rules, projectData, extracts } =
+                -- Replace `config` by `rules` next time you call reviewV2
+                -- Replace `Nothing` by `projectData` next time you call reviewV2
+                Rule.reviewV3 config Nothing project
+        in
+        doSomethingWithTheseValues
+
+The resulting `List Rule` is the same list of rules given as input, but with an
+updated internal cache to make it faster to re-run the rules on the same project.
+If you plan on re-reviewing with the same rules and project, for instance to
+review the project after a file has changed, you may want to store the rules in
+your `Model`.
+
+The rules are functions, so doing so will make your model unable to be
+exported/imported with `elm/browser`'s debugger, and may cause a crash if you try
+to compare them or the model that holds them.
+
+-}
+reviewV3 : List Rule -> Maybe ProjectData -> Project -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+reviewV3 rules maybeProjectData project =
+    case
+        checkForConfigurationErrors rules
+            |> Result.andThen (\() -> checkForModulesThatFailedToParse project)
+            |> Result.andThen (\() -> checkForDuplicateModules project)
+            |> Result.andThen (\() -> getModulesSortedByImport project)
+    of
+        Ok nodeContexts ->
             runReview project rules maybeProjectData nodeContexts
 
         Err errors ->
             { errors = errors
             , rules = rules
             , projectData = maybeProjectData
+            , extracts = Dict.empty
             }
 
 
@@ -571,53 +638,6 @@ checkForConfigurationErrors rules =
 
     else
         Err errors
-
-
-runReview : Project -> List Rule -> Maybe ProjectData -> List (Graph.NodeContext ModuleName ()) -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData }
-runReview ((Project p) as project) rules maybeProjectData nodeContexts =
-    let
-        scopeResult : { projectData : Maybe ProjectData, lookupTables : Maybe (Dict ModuleName ModuleNameLookupTable) }
-        scopeResult =
-            if needsToComputeScope rules then
-                let
-                    { cache, extract } =
-                        runProjectVisitor
-                            scopeRule
-                            (Maybe.map extractProjectData maybeProjectData)
-                            Exceptions.init
-                            project
-                            nodeContexts
-                in
-                { projectData = Just (ProjectData cache)
-                , lookupTables =
-                    case extract of
-                        Just (ModuleNameLookupTableExtract lookupTable) ->
-                            Just lookupTable
-
-                        Just (JsonExtract _) ->
-                            Nothing
-
-                        Nothing ->
-                            Nothing
-                }
-
-            else
-                { projectData = Nothing
-                , lookupTables = Nothing
-                }
-
-        projectWithLookupTables : Project
-        projectWithLookupTables =
-            Project { p | moduleNameLookupTables = scopeResult.lookupTables }
-    in
-    let
-        ( errors, newRules ) =
-            runRules rules projectWithLookupTables nodeContexts
-    in
-    { errors = ListExtra.orderIndependentMap errorToReviewError errors
-    , rules = newRules
-    , projectData = scopeResult.projectData
-    }
 
 
 checkForModulesThatFailedToParse : Project -> Result (List ReviewError) ()
@@ -769,6 +789,55 @@ wrapInCycle string =
     "    ┌─────┐\n    │    " ++ string ++ "\n    └─────┘"
 
 
+runReview : Project -> List Rule -> Maybe ProjectData -> List (Graph.NodeContext ModuleName ()) -> { errors : List ReviewError, rules : List Rule, projectData : Maybe ProjectData, extracts : Dict String Encode.Value }
+runReview ((Project p) as project) rules maybeProjectData nodeContexts =
+    let
+        scopeResult : { projectData : Maybe ProjectData, lookupTables : Maybe (Dict ModuleName ModuleNameLookupTable) }
+        scopeResult =
+            if needsToComputeScope rules then
+                let
+                    { cache, extract } =
+                        runProjectVisitor
+                            scopeRule
+                            (Maybe.map extractProjectData maybeProjectData)
+                            Exceptions.init
+                            project
+                            nodeContexts
+                in
+                { projectData = Just (ProjectData cache)
+                , lookupTables =
+                    case extract of
+                        Just (ModuleNameLookupTableExtract lookupTable) ->
+                            Just lookupTable
+
+                        Just (JsonExtract _) ->
+                            Nothing
+
+                        Nothing ->
+                            Nothing
+                }
+
+            else
+                { projectData = Nothing
+                , lookupTables = Nothing
+                }
+
+        projectWithLookupTables : Project
+        projectWithLookupTables =
+            Project { p | moduleNameLookupTables = scopeResult.lookupTables }
+    in
+    let
+        runResult : { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
+        runResult =
+            runRules rules projectWithLookupTables nodeContexts
+    in
+    { errors = ListExtra.orderIndependentMap errorToReviewError runResult.errors
+    , rules = runResult.rules
+    , projectData = scopeResult.projectData
+    , extracts = runResult.extracts
+    }
+
+
 
 -- PROJECT DATA
 
@@ -818,20 +887,28 @@ duplicateModulesGlobalError duplicate =
         |> errorToReviewError
 
 
-runRules : List Rule -> Project -> List (Graph.NodeContext ModuleName ()) -> ( List (Error {}), List Rule )
-runRules rules project nodeContexts =
+runRules :
+    List Rule
+    -> Project
+    -> List (Graph.NodeContext ModuleName ())
+    -> { errors : List (Error {}), rules : List Rule, extracts : Dict String Encode.Value }
+runRules initialRules project nodeContexts =
     List.foldl
-        (\(Rule { exceptions, ruleImplementation }) ( errors, previousRules ) ->
+        (\(Rule { exceptions, ruleImplementation }) { errors, rules, extracts } ->
             let
                 ( ruleErrors, ruleWithCache ) =
                     ruleImplementation exceptions project nodeContexts
             in
-            ( ListExtra.orderIndependentMapAppend removeErrorPhantomType ruleErrors errors
-            , ruleWithCache :: previousRules
-            )
+            { errors = ListExtra.orderIndependentMapAppend removeErrorPhantomType ruleErrors errors
+            , rules = ruleWithCache :: rules
+            , extracts = extracts
+            }
         )
-        ( [], [] )
-        rules
+        { errors = []
+        , rules = []
+        , extracts = Dict.empty
+        }
+        initialRules
 
 
 duplicateModuleNames : Dict ModuleName String -> List ProjectModule -> Maybe { moduleName : ModuleName, paths : List String }

--- a/src/Review/Test.elm
+++ b/src/Review/Test.elm
@@ -120,6 +120,7 @@ import Json.Encode as Encode
 import Review.Error as Error
 import Review.FileParser as FileParser
 import Review.Fix as Fix
+import Review.Options as ReviewOptions
 import Review.Project as Project exposing (Project, ProjectModule)
 import Review.Rule as Rule exposing (ReviewError, Rule)
 import Review.Test.Dependencies exposing (projectWithElmCore)
@@ -413,7 +414,7 @@ runOnModulesWithProjectDataHelp project rule sources =
                         let
                             runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe Rule.ProjectData, extracts : Dict String Encode.Value }
                             runResult =
-                                Rule.reviewV3 { extract = True } [ rule ] Nothing projectWithModules
+                                Rule.reviewV3 (ReviewOptions.withDataExtraction True ReviewOptions.defaults) [ rule ] Nothing projectWithModules
 
                             errors : List ReviewError
                             errors =

--- a/src/Review/Test.elm
+++ b/src/Review/Test.elm
@@ -412,7 +412,7 @@ runOnModulesWithProjectDataHelp project rule sources =
                         let
                             runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe Rule.ProjectData, extracts : Dict String Encode.Value }
                             runResult =
-                                Rule.reviewV3 [ rule ] Nothing projectWithModules
+                                Rule.reviewV3 { extract = True } [ rule ] Nothing projectWithModules
 
                             errors : List ReviewError
                             errors =

--- a/src/Review/Test.elm
+++ b/src/Review/Test.elm
@@ -3,6 +3,7 @@ module Review.Test exposing
     , ExpectedError, expectNoErrors, expectErrors, error, atExactly, whenFixed, expectErrorsForModules, expectErrorsForElmJson, expectErrorsForReadme
     , expectGlobalErrors, expectGlobalAndLocalErrors, expectGlobalAndModuleErrors
     , expectConfigurationError
+    , expectDataExtract
     )
 
 {-| Module that helps you test your rules, using [`elm-test`](https://package.elm-lang.org/packages/elm-explorations/test/latest/).
@@ -103,14 +104,18 @@ for this module.
 @docs ExpectedError, expectNoErrors, expectErrors, error, atExactly, whenFixed, expectErrorsForModules, expectErrorsForElmJson, expectErrorsForReadme
 @docs expectGlobalErrors, expectGlobalAndLocalErrors, expectGlobalAndModuleErrors
 @docs expectConfigurationError
+@docs expectDataExtract
 
 -}
 
 import Array exposing (Array)
+import Dict exposing (Dict)
 import Elm.Syntax.Module as Module
 import Elm.Syntax.Node as Node
 import Elm.Syntax.Range exposing (Range)
 import Expect exposing (Expectation)
+import Json.Decode as Decode
+import Json.Encode as Encode
 import Review.Error as Error
 import Review.FileParser as FileParser
 import Review.Fix as Fix
@@ -120,6 +125,7 @@ import Review.Test.Dependencies exposing (projectWithElmCore)
 import Review.Test.FailureMessage as FailureMessage
 import Set exposing (Set)
 import Unicode
+import Vendor.Diff as Diff
 import Vendor.ListExtra as ListExtra
 
 
@@ -132,7 +138,7 @@ import Vendor.ListExtra as ListExtra
 type ReviewResult
     = ConfigurationError { message : String, details : List String }
     | FailedRun String
-    | SuccessfulRun (List GlobalError) (List SuccessfulRunResult)
+    | SuccessfulRun (List GlobalError) (List SuccessfulRunResult) ExtractResult
 
 
 type alias GlobalError =
@@ -154,6 +160,11 @@ type alias CodeInspector =
     , getCodeAtLocation : Range -> Maybe String
     , checkIfLocationIsAmbiguous : ReviewError -> String -> Expectation
     }
+
+
+type ExtractResult
+    = RuleHasNoExtractor
+    | Extracted (Maybe Encode.Value)
 
 
 {-| An expectation for an error. Use [`error`](#error) to create one.
@@ -399,11 +410,21 @@ runOnModulesWithProjectDataHelp project rule sources =
 
                     Nothing ->
                         let
+                            runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe Rule.ProjectData, extracts : Dict String Encode.Value }
+                            runResult =
+                                Rule.reviewV3 [ rule ] Nothing projectWithModules
+
                             errors : List ReviewError
                             errors =
-                                projectWithModules
-                                    |> Rule.reviewV2 [ rule ] Nothing
-                                    |> .errors
+                                runResult.errors
+
+                            extract : ExtractResult
+                            extract =
+                                if Rule.ruleExtractsData rule then
+                                    Extracted (Dict.get (Rule.ruleName rule) runResult.extracts)
+
+                                else
+                                    RuleHasNoExtractor
                         in
                         case ListExtra.find (\err -> Rule.errorTarget err == Error.Global) errors of
                             Just globalError ->
@@ -425,7 +446,7 @@ runOnModulesWithProjectDataHelp project rule sources =
                                             |> List.filter (\error_ -> Rule.errorTarget error_ == Error.UserGlobal)
                                             |> List.map (\error_ -> { message = Rule.errorMessage error_, details = Rule.errorDetails error_ })
                                 in
-                                SuccessfulRun globalErrors fileErrors
+                                SuccessfulRun globalErrors fileErrors extract
 
 
 hasOneElement : List a -> Bool
@@ -749,7 +770,7 @@ expectGlobalAndLocalErrors { global, local } reviewResult =
         FailedRun errorMessage ->
             Expect.fail errorMessage
 
-        SuccessfulRun globalErrors runResults ->
+        SuccessfulRun globalErrors runResults extract ->
             Expect.all
                 [ \() ->
                     if List.isEmpty global then
@@ -768,6 +789,7 @@ expectGlobalAndLocalErrors { global, local } reviewResult =
 
                             _ ->
                                 Expect.fail FailureMessage.needToUsedExpectErrorsForModules
+                , \() -> expectNoExtract extract
                 ]
                 ()
 
@@ -791,7 +813,7 @@ expectGlobalAndModuleErrors { global, modules } reviewResult =
         FailedRun errorMessage ->
             Expect.fail errorMessage
 
-        SuccessfulRun globalErrors runResults ->
+        SuccessfulRun globalErrors runResults extract ->
             Expect.all
                 [ \() ->
                     if List.isEmpty global then
@@ -800,6 +822,7 @@ expectGlobalAndModuleErrors { global, modules } reviewResult =
                     else
                         checkAllGlobalErrorsMatch (List.length global) { expected = global, actual = globalErrors }
                 , \() -> expectErrorsForModulesHelp modules runResults
+                , \() -> expectNoExtract extract
                 ]
                 ()
 
@@ -1534,3 +1557,74 @@ expectConfigurationErrorDetailsMatch expectedError configurationError =
 
     else
         Expect.pass
+
+
+expectNoExtract : ExtractResult -> Expectation
+expectNoExtract maybeExtract =
+    case maybeExtract of
+        Extracted (Just _) ->
+            Expect.fail FailureMessage.needToUsedExpectErrorsForModules
+
+        Extracted Nothing ->
+            Expect.pass
+
+        RuleHasNoExtractor ->
+            Expect.pass
+
+
+expectDataExtract : String -> ReviewResult -> Expectation
+expectDataExtract expectedExtract reviewResult =
+    case reviewResult of
+        ConfigurationError configurationError ->
+            Expect.fail (FailureMessage.unexpectedConfigurationError configurationError)
+
+        FailedRun errorMessage ->
+            Expect.fail errorMessage
+
+        SuccessfulRun globalErrors runResults extract ->
+            Expect.all
+                [ \() -> expectNoGlobalErrors globalErrors
+                , \() -> expectNoModuleErrors runResults
+                , \() -> expectDataExtractContent expectedExtract extract
+                ]
+                ()
+
+
+expectDataExtractContent : String -> ExtractResult -> Expectation
+expectDataExtractContent rawExpected maybeActualExtract =
+    case maybeActualExtract of
+        RuleHasNoExtractor ->
+            Expect.fail FailureMessage.missingExtract
+
+        Extracted Nothing ->
+            Expect.fail FailureMessage.missingExtract
+
+        Extracted (Just actual) ->
+            case Decode.decodeString Decode.value rawExpected of
+                Err parsingError ->
+                    Expect.fail (FailureMessage.invalidJsonForExpectedDataExtract parsingError)
+
+                Ok expected ->
+                    let
+                        differences : List (Diff.Change String)
+                        differences =
+                            Diff.diffLines (Encode.encode 2 actual) (Encode.encode 2 expected)
+                    in
+                    if containsDifferences differences then
+                        Expect.fail (FailureMessage.extractMismatch actual expected differences)
+
+                    else
+                        Expect.pass
+
+
+containsDifferences : List (Diff.Change a) -> Bool
+containsDifferences changes =
+    case changes of
+        [] ->
+            False
+
+        (Diff.NoChange _) :: restOfChanges ->
+            containsDifferences restOfChanges
+
+        _ ->
+            True

--- a/src/Review/Test.elm
+++ b/src/Review/Test.elm
@@ -412,7 +412,7 @@ runOnModulesWithProjectDataHelp project rule sources =
 
                     Nothing ->
                         let
-                            runResult : { errors : List ReviewError, rules : List Rule, projectData : Maybe Rule.ProjectData, extracts : Dict String Encode.Value }
+                            runResult : { errors : List ReviewError, rules : List Rule, project : Project, projectData : Maybe Rule.ProjectData, extracts : Dict String Encode.Value }
                             runResult =
                                 Rule.reviewV3 (ReviewOptions.withDataExtraction True ReviewOptions.defaults) [ rule ] Nothing projectWithModules
 

--- a/src/Review/Test/FailureMessage.elm
+++ b/src/Review/Test/FailureMessage.elm
@@ -7,7 +7,7 @@ module Review.Test.FailureMessage exposing
     , didNotExpectGlobalErrors, expectedMoreGlobalErrors, fixedCodeWhitespaceMismatch, messageMismatchForConfigurationError
     , messageMismatchForGlobalError, missingConfigurationError, tooManyGlobalErrors
     , unexpectedConfigurationError, unexpectedConfigurationErrorDetails, unexpectedGlobalErrorDetails
-    , unexpectedExtract, missingExtract, invalidJsonForExpectedDataExtract, extractMismatch
+    , unexpectedExtract, missingExtract, invalidJsonForExpectedDataExtract, extractMismatch, specifiedMultipleExtracts
     )
 
 {-| Failure messages for the `Review.Test` module.
@@ -23,7 +23,7 @@ module Review.Test.FailureMessage exposing
 @docs didNotExpectGlobalErrors, expectedMoreGlobalErrors, fixedCodeWhitespaceMismatch, messageMismatchForConfigurationError
 @docs messageMismatchForGlobalError, missingConfigurationError, tooManyGlobalErrors
 @docs unexpectedConfigurationError, unexpectedConfigurationErrorDetails, unexpectedGlobalErrorDetails
-@docs unexpectedExtract, missingExtract, invalidJsonForExpectedDataExtract, extractMismatch
+@docs unexpectedExtract, missingExtract, invalidJsonForExpectedDataExtract, extractMismatch, specifiedMultipleExtracts
 
 -}
 
@@ -680,6 +680,15 @@ when I was expecting the following:
 Here are the differences:
 
 """ ++ formatJsonDiff differences)
+
+
+specifiedMultipleExtracts : String
+specifiedMultipleExtracts =
+    failureMessage "SPECIFIED MULTIPLE DATA EXTRACTS"
+        """You specified multiple expectations for a data extract. Contrary to errors,
+it is only possible to have a single data extract at most. Please remove
+expectations so that you end up with only a single expectation about the
+data extract."""
 
 
 formatJsonDiff : List (Diff.Change String) -> String

--- a/tests/Review/Rule/DataExtractTest.elm
+++ b/tests/Review/Rule/DataExtractTest.elm
@@ -1,0 +1,183 @@
+module Review.Rule.DataExtractTest exposing (all)
+
+import Dict exposing (Dict)
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.Node as Node exposing (Node)
+import Json.Encode as Encode
+import Review.Rule as Rule exposing (Rule)
+import Review.Test
+import Test exposing (Test, test)
+
+
+type alias ProjectContext =
+    Dict String (List String)
+
+
+type alias ModuleContext =
+    { declarations : List String
+    }
+
+
+rule : Maybe (Rule.Error { useErrorForModule : () }) -> Rule
+rule maybeError =
+    Rule.newProjectRuleSchema "TestRule" Dict.empty
+        |> Rule.withElmJsonProjectVisitor (\_ context -> ( [], context ))
+        |> Rule.withModuleVisitor moduleVisitor
+        |> Rule.withModuleContextUsingContextCreator
+            { fromProjectToModule = fromProjectToModule
+            , fromModuleToProject = fromModuleToProject
+            , foldProjectContexts = foldProjectContexts
+            }
+        |> Rule.withFinalProjectEvaluation
+            (\_ ->
+                case maybeError of
+                    Just error ->
+                        [ error ]
+
+                    Nothing ->
+                        []
+            )
+        |> Rule.withDataExtractor dataExtractor
+        |> Rule.fromProjectRuleSchema
+
+
+moduleVisitor : Rule.ModuleRuleSchema schemaState ModuleContext -> Rule.ModuleRuleSchema { schemaState | hasAtLeastOneVisitor : () } ModuleContext
+moduleVisitor schema =
+    schema
+        |> Rule.withDeclarationListVisitor (\node context -> ( [], declarationListVisitor node context ))
+
+
+fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
+fromProjectToModule =
+    Rule.initContextCreator
+        (\_ ->
+            { declarations = []
+            }
+        )
+
+
+fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
+fromModuleToProject =
+    Rule.initContextCreator
+        (\moduleName moduleContext ->
+            Dict.singleton (String.join "." moduleName) moduleContext.declarations
+        )
+        |> Rule.withModuleName
+
+
+foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
+foldProjectContexts =
+    Dict.union
+
+
+declarationListVisitor : List (Node Declaration) -> ModuleContext -> ModuleContext
+declarationListVisitor nodes context =
+    let
+        declarations : List String
+        declarations =
+            List.filterMap
+                (\node ->
+                    case Node.value node of
+                        Declaration.FunctionDeclaration { declaration } ->
+                            declaration
+                                |> Node.value
+                                |> .name
+                                |> Node.value
+                                |> Just
+
+                        _ ->
+                            Nothing
+                )
+                nodes
+    in
+    { context | declarations = declarations }
+
+
+dataExtractor : ProjectContext -> Encode.Value
+dataExtractor declarations =
+    Encode.object
+        [ ( "foo", Encode.string "bar" )
+        , ( "other", Encode.list Encode.int [ 1, 2, 3 ] )
+        , ( "declarations", Encode.dict identity (Encode.list Encode.string) declarations )
+        , ( "null", Encode.null )
+        ]
+
+
+all : Test
+all =
+    Test.describe "Extract data"
+        [ test "should be able to extract data from the rule as JSON" <|
+            \() ->
+                [ """module A exposing (..)
+import B
+a = 1
+b = 2
+c = 3
+"""
+                , """module B exposing (..)
+x = 1
+y = 2
+z = 3
+"""
+                ]
+                    |> Review.Test.runOnModules (rule Nothing)
+                    -- Bad formatting is on purpose
+                    |> Review.Test.expectDataExtract """{
+        "foo": "bar",
+                    "other": [ 1, 2, 3 ],
+  "declarations": {
+    "A": [ "a", "b", "c" ],
+    "B": [ "x", "y", "z" ]
+  }
+,"null": null}"""
+        , test "should extract even if there are errors" <|
+            \() ->
+                [ """module A exposing (..)
+import B
+a = 1
+b = 2
+c = 3
+"""
+                , """module B exposing (..)
+x = 1
+y = 2
+z = 3
+"""
+                ]
+                    |> Review.Test.runOnModules (rule (Just (Rule.globalError { message = "message", details = [ "details" ] })))
+                    |> Review.Test.expectMultiple
+                        [ Review.Test.globalError [ { message = "message", details = [ "details" ] } ]
+                        , Review.Test.dataExtract """{
+        "foo": "bar",
+                    "other": [ 1, 2, 3 ],
+  "declarations": {
+    "A": [ "a", "b", "c" ],
+    "B": [ "x", "y", "z" ]
+  }
+,"null": null}"""
+                        ]
+        , test "should prevent extract when an error prevents it" <|
+            \() ->
+                [ """module A exposing (..)
+import B
+a = 1
+b = 2
+c = 3
+"""
+                , """module B exposing (..)
+x = 1
+y = 2
+z = 3
+"""
+                ]
+                    |> Review.Test.runOnModules
+                        (rule
+                            (Just
+                                (Rule.globalError { message = "message", details = [ "details" ] }
+                                    |> Rule.preventExtract
+                                )
+                            )
+                        )
+                    |> Review.Test.expectGlobalErrors
+                        [ { message = "message", details = [ "details" ] } ]
+        ]


### PR DESCRIPTION
There's a very interesting feature for `elm-review` that I've kept in the closet so far and not released yet (I was fine-tuning it and then had to stop working on it for a while).

The feature is being able to **extract** information from `elm-review`'s analysis. Currently `elm-review` is only able to report errors, and that's it. But it has I think a wonderful API to go through a project and extract information, and I think we could make use of it to get information from our project.

Here is an example: https://github.com/jfmengels/elm-review/blob/extracts/tests/Review/Rule/DataExtractTest.elm

It's basically just like a normal rule, but it has an additional `|> Rule.withDataExtractor dataExtractor` function, and this `dataExtractor` is a simple `ProjectContext -> Json.Encode.Value` function. The idea is that you collect anything that you want using the regular `elm-review` visitors, and then you export that to JSON format.

To access that information, you then run `elm-review` with `--report=json`. If your rule name was `Some.Rule`, then you'd have a JSON object with a key `"Some.Rule"` whose value is what you extracted to a JSON value.

I think there are a lot of potential use-cases.
We could have community-created graphs for our project. For instance you could collect the imports and create a DOT graph for the project, as Elm Analyze used to do. Or you can draw one for specific functions. I would love to see graphs of things like which `Msg` trigger which other `Msg` in an update function, so you can have a much clearer vision of what happens in a module.

You could track which CSS classes have been used by your project, and then compare that with your CSS files to clean them up.
I have been using this to collect security issues. Given a vulnerable function, find out which other functions use it and are vulnerable by transitivity.

If we support creating files in automatic fixes, we could use the information to generate Elm code (manually or using `elm-codegen`) based on data that is found in our Elm files.

With #138, we'd be able to collect a lot of information, and the possibilities become endless.

---

This PR also includes a new API for testing rules
```elm
-- ....
|> Review.Test.expectMultiple
    [ Review.Test.globalError [ { message = "message", details = [ "details" ] } ]
    , Review.Test.dataExtract "<some-data>"
    ]
```

The combination of things to test for (local errors, errors for multiple modules, global errors, data extracts and any combination of these) was becoming too much. It took me too long to come up with this API, but in a future version I might remove the combination functions (`expectGlobalAndLocalErrors`, `expectGlobalAndModuleErrors`, ...) in favor of this API.


---

If you want to try it out, it's a bit annoying but you can. You need to check out the `jfmengels/elm-review` and `jfmengels/node-elm-review` projects on your machine, go to the `extracts` branch on both, then you add your rule to the `review/src/ReviewConfig.elm` inside of `jfmengels/elm-review`, and then you can run

```LOCAL_ELM_REVIEW_SRC=<path to jfmengels/elm-review>/src <path to jfmengels/node-elm-review>/bin/elm-review --config <path to jfmengels/elm-review>/review --report=json --rules Your.Rule.Name```

There are still a few details that I'm iffy on:
* Is the JSON output sufficient? Should there be a way to visualize data for a single rule without going through `--report=json`? It would be cool to see visual graphs in `--watch` mode for instance. So that if you change your `update` function, you see the updated graph right away.

Feedback welcome!