### PR TITLE
Compute the module docs for modules when it's missing

### DIFF
--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -193,7 +193,6 @@ computeOnlyModuleDocs :
     -> ( Elm.Docs.Module, ProjectCache )
 computeOnlyModuleDocs moduleName module_ modulesByModuleName deps projectCache =
     let
-        -- Can we skip going all the way back to the top?
         ( imported, projectCacheWithComputedImports ) =
             List.foldl
                 (computeImportedModulesDocs modulesByModuleName deps)

--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -145,7 +145,8 @@ compute moduleName module_ project =
                 moduleContext : Context
                 moduleContext =
                     fromProjectToModule moduleName imported
-                        |> collectLookupTable module_.ast
+                        |> collectModuleDocs module_.ast
+                        |> collectLookupTable module_.ast.declarations
             in
             ( moduleContext.lookupTable
             , Dict.insert moduleName
@@ -206,16 +207,15 @@ fromProjectToModule moduleName modules =
     }
 
 
-collectLookupTable : Elm.Syntax.File.File -> Context -> Context
-collectLookupTable ast context =
+collectModuleDocs : Elm.Syntax.File.File -> Context -> Context
+collectModuleDocs ast context =
     List.foldl importVisitor context (elmCorePrelude ++ ast.imports)
         |> moduleDefinitionVisitor ast.moduleDefinition
         |> declarationListVisitor ast.declarations
-        |> visitDeclarationsAndExpressions ast.declarations
 
 
-visitDeclarationsAndExpressions : List (Node Declaration) -> Context -> Context
-visitDeclarationsAndExpressions declarations context =
+collectLookupTable : List (Node Declaration) -> Context -> Context
+collectLookupTable declarations context =
     List.foldl
         (\declaration ctx ->
             case Node.value declaration of

--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -101,7 +101,7 @@ compute moduleName module_ project =
 
         ( imported, projectCacheWithComputedImports ) =
             List.foldl
-                (\(Node _ import_) acc ->
+                (\(Node _ import_) accImported ->
                     let
                         importedModuleName : ModuleName
                         importedModuleName =
@@ -118,10 +118,10 @@ compute moduleName module_ project =
                     in
                     case maybeImportedModule of
                         Just importedModule ->
-                            Dict.insert importedModuleName importedModule acc
+                            Dict.insert importedModuleName importedModule accImported
 
                         Nothing ->
-                            acc
+                            accImported
                 )
                 Dict.empty
                 (elmCorePrelude ++ module_.ast.imports)

--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -99,6 +99,10 @@ compute moduleName module_ project =
                 Nothing ->
                     computeDependencies project
 
+        knownProjectModules : Set ModuleName
+        knownProjectModules =
+            ValidProject.projectModuleNames project
+
         ( imported, projectCacheWithComputedImports ) =
             List.foldl
                 (\(Node _ import_) ( accImported, accProjectCache ) ->

--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -113,12 +113,17 @@ compute moduleName module_ project =
 
                         maybeImportedModule : Maybe Elm.Docs.Module
                         maybeImportedModule =
-                            case Dict.get importedModuleName accProjectCache.modules of
-                                Just importedModule ->
-                                    Just importedModule
+                            if Set.member importedModuleName knownProjectModules then
+                                case Dict.get importedModuleName accProjectCache.modules of
+                                    Just importedModule ->
+                                        Just importedModule
 
-                                Nothing ->
-                                    Dict.get importedModuleName deps
+                                    Nothing ->
+                                        -- TODO Compute modules for that element
+                                        Dict.get importedModuleName deps
+
+                            else
+                                Dict.get importedModuleName deps
                     in
                     case maybeImportedModule of
                         Just importedModule ->

--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -101,7 +101,7 @@ compute moduleName module_ project =
 
         ( imported, projectCacheWithComputedImports ) =
             List.foldl
-                (\(Node _ import_) accImported ->
+                (\(Node _ import_) ( accImported, accProjectCache ) ->
                     let
                         importedModuleName : ModuleName
                         importedModuleName =
@@ -109,7 +109,7 @@ compute moduleName module_ project =
 
                         maybeImportedModule : Maybe Elm.Docs.Module
                         maybeImportedModule =
-                            case Dict.get importedModuleName projectCache.modules of
+                            case Dict.get importedModuleName accProjectCache.modules of
                                 Just importedModule ->
                                     Just importedModule
 
@@ -118,14 +118,13 @@ compute moduleName module_ project =
                     in
                     case maybeImportedModule of
                         Just importedModule ->
-                            Dict.insert importedModuleName importedModule accImported
+                            ( Dict.insert importedModuleName importedModule accImported, accProjectCache )
 
                         Nothing ->
-                            accImported
+                            ( accImported, accProjectCache )
                 )
-                Dict.empty
+                ( Dict.empty, projectCache )
                 (elmCorePrelude ++ module_.ast.imports)
-                |> (\a -> ( a, projectCache ))
 
         cacheKey : ProjectCache.ModuleCacheKey
         cacheKey =

--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -105,35 +105,7 @@ compute moduleName module_ project =
 
         ( imported, projectCacheWithComputedImports ) =
             List.foldl
-                (\(Node _ import_) ( accImported, accProjectCache ) ->
-                    let
-                        importedModuleName : ModuleName
-                        importedModuleName =
-                            Node.value import_.moduleName
-                    in
-                    case Dict.get importedModuleName accProjectCache.modules of
-                        Just importedModule ->
-                            ( Dict.insert importedModuleName importedModule accImported, accProjectCache )
-
-                        Nothing ->
-                            case Dict.get importedModuleName modulesByModuleName of
-                                Just importedModule ->
-                                    let
-                                        ( importedModuleDocs, newProjectCacheAcc ) =
-                                            computeOnlyModuleDocs importedModuleName importedModule modulesByModuleName deps accProjectCache
-                                    in
-                                    ( Dict.insert importedModuleName importedModuleDocs accImported
-                                    , newProjectCacheAcc
-                                    )
-
-                                Nothing ->
-                                    case Dict.get importedModuleName deps of
-                                        Just importedModule ->
-                                            ( Dict.insert importedModuleName importedModule accImported, accProjectCache )
-
-                                        Nothing ->
-                                            ( accImported, accProjectCache )
-                )
+                (computeImportedModulesDocs modulesByModuleName deps)
                 ( Dict.empty, projectCache )
                 (elmCorePrelude ++ module_.ast.imports)
 

--- a/src/Review/Project/Valid.elm
+++ b/src/Review/Project/Valid.elm
@@ -14,6 +14,7 @@ module Review.Project.Valid exposing
     , moduleZipper
     , parse
     , projectCache
+    , projectModuleNames
     , readme
     , readmeHash
     , toRegularProject
@@ -337,6 +338,11 @@ directDependencies (ValidProject project) =
 moduleGraph : ValidProject -> Graph FilePath ()
 moduleGraph (ValidProject project) =
     project.moduleGraph
+
+
+projectModuleNames : ValidProject -> Set ModuleName
+projectModuleNames (ValidProject project) =
+    project.projectModules
 
 
 getModuleByPath : String -> ValidProject -> Maybe ProjectModule

--- a/src/Review/Project/Valid.elm
+++ b/src/Review/Project/Valid.elm
@@ -51,6 +51,7 @@ type alias ValidProjectData =
     , readme : Maybe ( { path : String, content : String }, ContentHash )
     , dependencies : Dict String Dependency
     , directDependencies : Dict String Dependency
+    , projectModules : Set ModuleName
     , dependencyModules : Set ModuleName
     , sourceDirectories : List String
     , projectCache : ProjectCache
@@ -138,6 +139,7 @@ fromProjectAndGraph moduleGraph_ acyclicGraph (Project project) =
         , readme = project.readme
         , dependencies = project.dependencies
         , directDependencies = directDependencies_
+        , projectModules = computeProjectModules project.modules
         , dependencyModules = computeDependencyModules directDependencies_
         , sourceDirectories = project.sourceDirectories
         , projectCache = project.cache
@@ -177,6 +179,16 @@ computeDependencyModules directDependencies_ =
         )
         Set.empty
         directDependencies_
+
+
+computeProjectModules : Dict a ProjectModule -> Set ModuleName
+computeProjectModules modules =
+    Dict.foldl
+        (\_ module_ acc ->
+            Set.insert (getModuleName module_) acc
+        )
+        Set.empty
+        modules
 
 
 duplicateModuleNames : Dict ModuleName String -> List ProjectModule -> Maybe { moduleName : ModuleName, paths : List String }


### PR DESCRIPTION
The problem was related to caching: By re-using the cache from the file-system, we were also skipping the computation of the Elm.Docs.Module of the module, which is needed to compute the module name lookup table.

That created bugs like https://github.com/jfmengels/elm-review-unused/issues/75 where when a file is changed (but not its imports) then we'd compute the lookup table again, but without the Elm.Docs.Module-s from the imports, it would be incorrect and led to bad results.

Fixes https://github.com/jfmengels/elm-review-unused/issues/75