### PR TITLE
Improve the performance of cache checks

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -58,6 +58,7 @@ config =
             , "src/Review/Fix.elm"
             ]
     , NoUnused.CustomTypeConstructorArgs.rule
+        |> Rule.ignoreErrorsForFiles [ "src/Review/Cache/ContextHash.elm" ]
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -8,7 +8,7 @@ import Review.RequestedData exposing (RequestedData(..))
 type ModuleEntry error context
     = ModuleEntry
         { contentHash : ContentHash
-        , inputContextHash : ContextHash context
+        , inputContextHashes : ContextHash context
         , isFileIgnored : Bool
         , errors : List error
         , outputContext : context
@@ -17,7 +17,7 @@ type ModuleEntry error context
 
 createModuleEntry :
     { contentHash : ContentHash
-    , inputContextHash : ContextHash context
+    , inputContextHashes : ContextHash context
     , isFileIgnored : Bool
     , errors : List error
     , outputContext : context
@@ -40,7 +40,7 @@ errors (ModuleEntry entry) =
 match : ContentHash -> ContextHash context -> ModuleEntry error context -> { isFileIgnored : Bool, requestedData : RequestedData } -> Bool
 match contentHash context (ModuleEntry entry) { isFileIgnored, requestedData } =
     ContentHash.areEqual contentHash entry.contentHash
-        && ContextHash.areEqual context entry.inputContextHash
+        && ContextHash.areEqual context entry.inputContextHashes
         && (not (ruleCaresAboutIgnoredFiles requestedData) || isFileIgnored == entry.isFileIgnored)
 
 

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -57,6 +57,7 @@ type ProjectFileCache error context
         , inputContextHash : ContextHash context
         , errors : List error
         , outputContext : context
+        , outputContextHash : ContextHash context
         }
 
 
@@ -73,6 +74,7 @@ createEntryForProjectFileCache entry =
         , inputContextHash = entry.inputContextHash
         , errors = entry.errors
         , outputContext = entry.outputContext
+        , outputContextHash = ContextHash.create entry.outputContext
         }
 
 

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -8,7 +8,7 @@ import Review.RequestedData exposing (RequestedData(..))
 type ModuleEntry error context
     = ModuleEntry
         { contentHash : ContentHash
-        , inputContextHashes : ContextHash context
+        , inputContextHashes : List (ContextHash context)
         , isFileIgnored : Bool
         , errors : List error
         , outputContext : context
@@ -17,7 +17,7 @@ type ModuleEntry error context
 
 createModuleEntry :
     { contentHash : ContentHash
-    , inputContextHashes : ContextHash context
+    , inputContextHashes : List (ContextHash context)
     , isFileIgnored : Bool
     , errors : List error
     , outputContext : context
@@ -37,10 +37,10 @@ errors (ModuleEntry entry) =
     entry.errors
 
 
-match : ContentHash -> ContextHash context -> ModuleEntry error context -> { isFileIgnored : Bool, requestedData : RequestedData } -> Bool
-match contentHash context (ModuleEntry entry) { isFileIgnored, requestedData } =
+match : ContentHash -> List (ContextHash context) -> ModuleEntry error context -> { isFileIgnored : Bool, requestedData : RequestedData } -> Bool
+match contentHash inputContexts (ModuleEntry entry) { isFileIgnored, requestedData } =
     ContentHash.areEqual contentHash entry.contentHash
-        && ContextHash.areEqual context entry.inputContextHashes
+        && (inputContexts == entry.inputContextHashes)
         && (not (ruleCaresAboutIgnoredFiles requestedData) || isFileIgnored == entry.isFileIgnored)
 
 

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -126,7 +126,7 @@ matchProjectFileCache contentHash contexts (ProjectFileCache entry) =
 -}
 type EntryNoOutputContext output context
     = EntryNoOutputContext
-        { context : ContextHash context
+        { inputContextHashes : ContextHash context
         , output : output
         }
 
@@ -134,14 +134,14 @@ type EntryNoOutputContext output context
 createNoOutput : context -> output -> EntryNoOutputContext output context
 createNoOutput inputContext output =
     EntryNoOutputContext
-        { context = ContextHash.create inputContext
+        { inputContextHashes = ContextHash.create inputContext
         , output = output
         }
 
 
 matchNoOutput : ContextHash context -> EntryNoOutputContext error context -> Bool
 matchNoOutput context (EntryNoOutputContext entry) =
-    ContextHash.areEqual context entry.context
+    ContextHash.areEqual context entry.inputContextHashes
 
 
 outputForNoOutput : EntryNoOutputContext output context -> output

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -126,22 +126,22 @@ matchProjectFileCache contentHash contexts (ProjectFileCache entry) =
 -}
 type EntryNoOutputContext output context
     = EntryNoOutputContext
-        { inputContextHashes : ContextHash context
+        { inputContextHashes : List (ContextHash context)
         , output : output
         }
 
 
-createNoOutput : ContextHash context -> output -> EntryNoOutputContext output context
-createNoOutput inputContextHash output =
+createNoOutput : List (ContextHash context) -> output -> EntryNoOutputContext output context
+createNoOutput inputContextHashes output =
     EntryNoOutputContext
-        { inputContextHashes = inputContextHash
+        { inputContextHashes = inputContextHashes
         , output = output
         }
 
 
-matchNoOutput : ContextHash context -> EntryNoOutputContext error context -> Bool
+matchNoOutput : List (ContextHash context) -> EntryNoOutputContext error context -> Bool
 matchNoOutput context (EntryNoOutputContext entry) =
-    ContextHash.areEqual context entry.inputContextHashes
+    context == entry.inputContextHashes
 
 
 outputForNoOutput : EntryNoOutputContext output context -> output

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -131,10 +131,10 @@ type EntryNoOutputContext output context
         }
 
 
-createNoOutput : context -> output -> EntryNoOutputContext output context
-createNoOutput inputContext output =
+createNoOutput : ContextHash context -> output -> EntryNoOutputContext output context
+createNoOutput inputContextHash output =
     EntryNoOutputContext
-        { inputContextHashes = ContextHash.create inputContext
+        { inputContextHashes = inputContextHash
         , output = output
         }
 

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -23,8 +23,14 @@ createModuleEntry :
     , outputContext : context
     }
     -> ModuleEntry error context
-createModuleEntry =
+createModuleEntry entry =
     ModuleEntry
+        { contentHash = entry.contentHash
+        , inputContextHashes = entry.inputContextHashes
+        , isFileIgnored = entry.isFileIgnored
+        , errors = entry.errors
+        , outputContext = entry.outputContext
+        }
 
 
 outputContext : ModuleEntry error context -> context

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -1,4 +1,4 @@
-module Review.Cache exposing (EntryNoOutputContext, ModuleEntry, ProjectFileCache, createEntryForProjectFileCache, createModuleEntry, createNoOutput, errors, errorsForMaybeProjectFileCache, errorsFromProjectFileCache, match, matchNoOutput, matchProjectFileCache, outputContext, outputContextForProjectFileCache, outputContextHashForProjectFileCache, outputForNoOutput)
+module Review.Cache exposing (EntryNoOutputContext, ModuleEntry, ProjectFileCache, createEntryForProjectFileCache, createModuleEntry, createNoOutput, errors, errorsForMaybeProjectFileCache, errorsFromProjectFileCache, match, matchNoOutput, matchProjectFileCache, outputContext, outputContextForProjectFileCache, outputContextHash, outputContextHashForProjectFileCache, outputForNoOutput)
 
 import Review.Cache.ContentHash as ContentHash exposing (ContentHash)
 import Review.Cache.ContextHash as ContextHash exposing (ContextHash)
@@ -38,6 +38,11 @@ createModuleEntry entry =
 outputContext : ModuleEntry error context -> context
 outputContext (ModuleEntry entry) =
     entry.outputContext
+
+
+outputContextHash : ModuleEntry error context -> ContextHash context
+outputContextHash (ModuleEntry entry) =
+    entry.outputContextHash
 
 
 errors : ModuleEntry error context -> List error

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -12,6 +12,7 @@ type ModuleEntry error context
         , isFileIgnored : Bool
         , errors : List error
         , outputContext : context
+        , outputContextHash : ContextHash context
         }
 
 
@@ -30,6 +31,7 @@ createModuleEntry entry =
         , isFileIgnored = entry.isFileIgnored
         , errors = entry.errors
         , outputContext = entry.outputContext
+        , outputContextHash = ContextHash.create entry.outputContext
         }
 
 

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -71,7 +71,7 @@ type ProjectFileCache error context
 
 createEntryForProjectFileCache :
     { contentHash : Maybe ContentHash
-    , inputContextHash : ContextHash context
+    , inputContextHash : List (ContextHash context)
     , errors : List error
     , outputContext : context
     }
@@ -79,7 +79,7 @@ createEntryForProjectFileCache :
 createEntryForProjectFileCache entry =
     ProjectFileCache
         { contentHash = entry.contentHash
-        , inputContextHash = [ entry.inputContextHash ]
+        , inputContextHash = entry.inputContextHash
         , errors = entry.errors
         , outputContext = entry.outputContext
         , outputContextHash = ContextHash.create entry.outputContext

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -1,4 +1,4 @@
-module Review.Cache exposing (EntryNoOutputContext, ModuleEntry, ProjectFileCache, createEntryForProjectFileCache, createModuleEntry, createNoOutput, errors, errorsForMaybeProjectFileCache, errorsFromProjectFileCache, match, matchNoOutput, matchProjectFileCache, outputContext, outputContextForProjectFileCache, outputForNoOutput)
+module Review.Cache exposing (EntryNoOutputContext, ModuleEntry, ProjectFileCache, createEntryForProjectFileCache, createModuleEntry, createNoOutput, errors, errorsForMaybeProjectFileCache, errorsFromProjectFileCache, match, matchNoOutput, matchProjectFileCache, outputContext, outputContextForProjectFileCache, outputContextHashForProjectFileCache, outputForNoOutput)
 
 import Review.Cache.ContentHash as ContentHash exposing (ContentHash)
 import Review.Cache.ContextHash as ContextHash exposing (ContextHash)
@@ -89,6 +89,11 @@ createEntryForProjectFileCache entry =
 outputContextForProjectFileCache : ProjectFileCache error context -> context
 outputContextForProjectFileCache (ProjectFileCache entry) =
     entry.outputContext
+
+
+outputContextHashForProjectFileCache : ProjectFileCache error context -> ContextHash context
+outputContextHashForProjectFileCache (ProjectFileCache entry) =
+    entry.outputContextHash
 
 
 errorsFromProjectFileCache : ProjectFileCache error context -> List error

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -62,7 +62,7 @@ ruleCaresAboutIgnoredFiles (RequestedData { ignoredFiles }) =
 type ProjectFileCache error context
     = ProjectFileCache
         { contentHash : Maybe ContentHash
-        , inputContextHash : ContextHash context
+        , inputContextHash : List (ContextHash context)
         , errors : List error
         , outputContext : context
         , outputContextHash : ContextHash context
@@ -79,7 +79,7 @@ createEntryForProjectFileCache :
 createEntryForProjectFileCache entry =
     ProjectFileCache
         { contentHash = entry.contentHash
-        , inputContextHash = entry.inputContextHash
+        , inputContextHash = [ entry.inputContextHash ]
         , errors = entry.errors
         , outputContext = entry.outputContext
         , outputContextHash = ContextHash.create entry.outputContext
@@ -111,10 +111,10 @@ errorsForMaybeProjectFileCache maybeEntry =
             []
 
 
-matchProjectFileCache : Maybe ContentHash -> ContextHash context -> ProjectFileCache error context -> Bool
-matchProjectFileCache contentHash context (ProjectFileCache entry) =
+matchProjectFileCache : Maybe ContentHash -> List (ContextHash context) -> ProjectFileCache error context -> Bool
+matchProjectFileCache contentHash contexts (ProjectFileCache entry) =
     ContentHash.areEqualForMaybe contentHash entry.contentHash
-        && ContextHash.areEqual context entry.inputContextHash
+        && (contexts == entry.inputContextHash)
 
 
 {-| Variant for final operations like the final evaluation or the extract

--- a/src/Review/Cache.elm
+++ b/src/Review/Cache.elm
@@ -1,14 +1,14 @@
 module Review.Cache exposing (EntryNoOutputContext, ModuleEntry, ProjectFileCache, createEntryForProjectFileCache, createModuleEntry, createNoOutput, errors, errorsForMaybeProjectFileCache, errorsFromProjectFileCache, match, matchNoOutput, matchProjectFileCache, outputContext, outputContextForProjectFileCache, outputContextHash, outputContextHashForProjectFileCache, outputForNoOutput)
 
 import Review.Cache.ContentHash as ContentHash exposing (ContentHash)
-import Review.Cache.ContextHash as ContextHash exposing (ContextHash)
+import Review.Cache.ContextHash as ContextHash exposing (ComparableContextHash, ContextHash)
 import Review.RequestedData exposing (RequestedData(..))
 
 
 type ModuleEntry error context
     = ModuleEntry
         { contentHash : ContentHash
-        , inputContextHashes : List (ContextHash context)
+        , inputContextHashes : ComparableContextHash context
         , isFileIgnored : Bool
         , errors : List error
         , outputContext : context
@@ -18,7 +18,7 @@ type ModuleEntry error context
 
 createModuleEntry :
     { contentHash : ContentHash
-    , inputContextHashes : List (ContextHash context)
+    , inputContextHashes : ComparableContextHash context
     , isFileIgnored : Bool
     , errors : List error
     , outputContext : context
@@ -50,7 +50,7 @@ errors (ModuleEntry entry) =
     entry.errors
 
 
-match : ContentHash -> List (ContextHash context) -> ModuleEntry error context -> { isFileIgnored : Bool, requestedData : RequestedData } -> Bool
+match : ContentHash -> ComparableContextHash context -> ModuleEntry error context -> { isFileIgnored : Bool, requestedData : RequestedData } -> Bool
 match contentHash inputContexts (ModuleEntry entry) { isFileIgnored, requestedData } =
     ContentHash.areEqual contentHash entry.contentHash
         && (inputContexts == entry.inputContextHashes)
@@ -67,7 +67,7 @@ ruleCaresAboutIgnoredFiles (RequestedData { ignoredFiles }) =
 type ProjectFileCache error context
     = ProjectFileCache
         { contentHash : Maybe ContentHash
-        , inputContextHash : List (ContextHash context)
+        , inputContextHash : ComparableContextHash context
         , errors : List error
         , outputContext : context
         , outputContextHash : ContextHash context
@@ -76,7 +76,7 @@ type ProjectFileCache error context
 
 createEntryForProjectFileCache :
     { contentHash : Maybe ContentHash
-    , inputContextHash : List (ContextHash context)
+    , inputContextHash : ComparableContextHash context
     , errors : List error
     , outputContext : context
     }
@@ -116,7 +116,7 @@ errorsForMaybeProjectFileCache maybeEntry =
             []
 
 
-matchProjectFileCache : Maybe ContentHash -> List (ContextHash context) -> ProjectFileCache error context -> Bool
+matchProjectFileCache : Maybe ContentHash -> ComparableContextHash context -> ProjectFileCache error context -> Bool
 matchProjectFileCache contentHash contexts (ProjectFileCache entry) =
     ContentHash.areEqualForMaybe contentHash entry.contentHash
         && (contexts == entry.inputContextHash)
@@ -126,12 +126,12 @@ matchProjectFileCache contentHash contexts (ProjectFileCache entry) =
 -}
 type EntryNoOutputContext output context
     = EntryNoOutputContext
-        { inputContextHashes : List (ContextHash context)
+        { inputContextHashes : ComparableContextHash context
         , output : output
         }
 
 
-createNoOutput : List (ContextHash context) -> output -> EntryNoOutputContext output context
+createNoOutput : ComparableContextHash context -> output -> EntryNoOutputContext output context
 createNoOutput inputContextHashes output =
     EntryNoOutputContext
         { inputContextHashes = inputContextHashes
@@ -139,7 +139,7 @@ createNoOutput inputContextHashes output =
         }
 
 
-matchNoOutput : List (ContextHash context) -> EntryNoOutputContext error context -> Bool
+matchNoOutput : ComparableContextHash context -> EntryNoOutputContext error context -> Bool
 matchNoOutput context (EntryNoOutputContext entry) =
     context == entry.inputContextHashes
 

--- a/src/Review/Cache/ContextHash.elm
+++ b/src/Review/Cache/ContextHash.elm
@@ -14,11 +14,16 @@ type ComparableContextHash context
     = ComparableContextHash (List (ContextHash context))
 
 
-{-| Will be replaced by a function that will sort the context hashes (which will be hashed values) in optimized mode.
--}
 toComparable : List (ContextHash projectContext) -> ComparableContextHash projectContext
 toComparable list =
-    ComparableContextHash list
+    ComparableContextHash (sort list)
+
+
+{-| Will be replaced by a function that will sort the context hashes (which will be hashed values) in optimized mode.
+-}
+sort : a -> a
+sort =
+    identity
 
 
 createContextHashMarker : a -> a

--- a/src/Review/Cache/ContextHash.elm
+++ b/src/Review/Cache/ContextHash.elm
@@ -1,4 +1,4 @@
-module Review.Cache.ContextHash exposing (ContextHash, create)
+module Review.Cache.ContextHash exposing (ComparableContextHash, ContextHash, create, sortContextHashes)
 
 
 type ContextHash context
@@ -8,6 +8,15 @@ type ContextHash context
 create : context -> ContextHash context
 create context =
     ContextHash (createContextHashMarker context)
+
+
+type ComparableContextHash context
+    = ComparableContextHash (List (ContextHash context))
+
+
+sortContextHashes : List (ContextHash projectContext) -> ComparableContextHash projectContext
+sortContextHashes list =
+    ComparableContextHash list
 
 
 createContextHashMarker : a -> a

--- a/src/Review/Cache/ContextHash.elm
+++ b/src/Review/Cache/ContextHash.elm
@@ -1,4 +1,4 @@
-module Review.Cache.ContextHash exposing (ContextHash, areEqual, create)
+module Review.Cache.ContextHash exposing (ContextHash, create)
 
 
 type ContextHash context
@@ -13,8 +13,3 @@ create context =
 createContextHashMarker : a -> a
 createContextHashMarker context =
     context
-
-
-areEqual : ContextHash context -> ContextHash context -> Bool
-areEqual (ContextHash a) (ContextHash b) =
-    a == b

--- a/src/Review/Cache/ContextHash.elm
+++ b/src/Review/Cache/ContextHash.elm
@@ -14,6 +14,8 @@ type ComparableContextHash context
     = ComparableContextHash (List (ContextHash context))
 
 
+{-| Will be replaced by a function that will sort the context hashes (which will be hashed values) in optimized mode.
+-}
 toComparable : List (ContextHash projectContext) -> ComparableContextHash projectContext
 toComparable list =
     ComparableContextHash list

--- a/src/Review/Cache/ContextHash.elm
+++ b/src/Review/Cache/ContextHash.elm
@@ -1,4 +1,4 @@
-module Review.Cache.ContextHash exposing (ComparableContextHash, ContextHash, create, sortContextHashes)
+module Review.Cache.ContextHash exposing (ComparableContextHash, ContextHash, create, toComparable)
 
 
 type ContextHash context
@@ -14,8 +14,8 @@ type ComparableContextHash context
     = ComparableContextHash (List (ContextHash context))
 
 
-sortContextHashes : List (ContextHash projectContext) -> ComparableContextHash projectContext
-sortContextHashes list =
+toComparable : List (ContextHash projectContext) -> ComparableContextHash projectContext
+toComparable list =
     ComparableContextHash list
 
 

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5703,7 +5703,7 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
                                         Cache.createModuleEntry
                                             { contentHash = moduleContentHash
                                             , errors = errors
-                                            , inputContextHash = inputContextHash
+                                            , inputContextHashes = inputContextHash
                                             , isFileIgnored = isFileIgnored
                                             , outputContext = outputProjectContext
                                             }

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5670,10 +5670,6 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
             inputContextHashes =
                 computeProjectContextHashes traversalAndFolder project hidden.cache.moduleContexts incoming initialProjectContextHash
 
-            inputProjectContext : projectContext
-            inputProjectContext =
-                computeProjectContext traversalAndFolder project hidden.cache.moduleContexts incoming initialProjectContext
-
             isFileIgnored : Bool
             isFileIgnored =
                 not (Exceptions.isFileWeWantReportsFor exceptions filePath)
@@ -5697,6 +5693,11 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
                 Nothing
 
             Nothing ->
+                let
+                    inputProjectContext : projectContext
+                    inputProjectContext =
+                        computeProjectContext traversalAndFolder project hidden.cache.moduleContexts incoming initialProjectContext
+                in
                 Just
                     (\availableData ->
                         let

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5390,7 +5390,7 @@ createProjectVisitor schema hidden maybeVisitor possibleInputContexts computeCon
 
                         cachePredicate : ProjectFileCache projectContext -> Bool
                         cachePredicate elmJson =
-                            Cache.matchProjectFileCache contentHash inputContextHash elmJson
+                            Cache.matchProjectFileCache contentHash [ inputContextHash ] elmJson
                     in
                     case reuseProjectRuleCache cachePredicate cacheGetter hidden.cache of
                         Just entry ->
@@ -5455,7 +5455,7 @@ createDependenciesVisitor schema { exceptions } raise cache { allVisitor, direct
 
                         cachePredicate : ProjectFileCache projectContext -> Bool
                         cachePredicate entry =
-                            Cache.matchProjectFileCache dependenciesHash inputContextHash entry
+                            Cache.matchProjectFileCache dependenciesHash [ inputContextHash ] entry
                     in
                     case reuseProjectRuleCache cachePredicate .dependencies cache of
                         Just entry ->

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -4236,10 +4236,10 @@ computeFinalContextHashes schema cache =
                 (\_ cacheEntry acc -> Cache.outputContextHash cacheEntry :: acc)
                 projectContextHash
                 cache.moduleContexts
-                |> ContextHash.sortContextHashes
+                |> ContextHash.toComparable
 
         Nothing ->
-            ContextHash.sortContextHashes projectContextHash
+            ContextHash.toComparable projectContextHash
 
 
 computeFinalContext : ProjectRuleSchemaData projectContext moduleContext -> ProjectRuleCache projectContext -> projectContext
@@ -4937,7 +4937,7 @@ computeProjectContextHashes :
 computeProjectContextHashes traversalAndFolder project cache incoming initial =
     case traversalAndFolder of
         TraverseAllModulesInParallel _ ->
-            ContextHash.sortContextHashes initial
+            ContextHash.toComparable initial
 
         TraverseImportedModulesFirst _ ->
             let
@@ -4959,7 +4959,7 @@ computeProjectContextHashes traversalAndFolder project cache incoming initial =
                 )
                 initial
                 incoming
-                |> ContextHash.sortContextHashes
+                |> ContextHash.toComparable
 
 
 computeProjectContext :
@@ -5446,7 +5446,7 @@ createProjectVisitor schema hidden maybeVisitor possibleInputContexts computeCon
 
                         inputContextHash : ComparableContextHash projectContext
                         inputContextHash =
-                            ContextHash.sortContextHashes baseInputContextHash
+                            ContextHash.toComparable baseInputContextHash
 
                         contentHash : Maybe ContentHash
                         contentHash =
@@ -5510,7 +5510,7 @@ createDependenciesVisitor schema { exceptions } raise cache { allVisitor, direct
 
                         inputContextHash : ComparableContextHash projectContext
                         inputContextHash =
-                            ContextHash.sortContextHashes baseInputContextHash
+                            ContextHash.toComparable baseInputContextHash
 
                         dependenciesHash : Maybe ContentHash
                         dependenciesHash =

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -309,7 +309,7 @@ import Elm.Syntax.Range as Range exposing (Range)
 import Json.Encode as Encode
 import Review.Cache as Cache
 import Review.Cache.ContentHash exposing (ContentHash)
-import Review.Cache.ContextHash as ContextHash exposing (ContextHash)
+import Review.Cache.ContextHash exposing (ContextHash)
 import Review.ElmProjectEncoder
 import Review.Error exposing (InternalError)
 import Review.Exceptions as Exceptions exposing (Exceptions)

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -4231,7 +4231,7 @@ computeFinalContextHashes schema cache =
                     TraverseAllModulesInParallel Nothing
     in
     case getFolderFromTraversal traversalAndFolder of
-        Just { foldProjectContexts } ->
+        Just _ ->
             Dict.foldl
                 (\_ cacheEntry acc -> Cache.outputContextHash cacheEntry :: acc)
                 projectContextHash

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5409,7 +5409,7 @@ createProjectVisitor schema hidden maybeVisitor possibleInputContexts computeCon
                             , Cache.createEntryForProjectFileCache
                                 { contentHash = contentHash
                                 , errors = errors
-                                , inputContextHash = inputContextHash
+                                , inputContextHash = [ inputContextHash ]
                                 , outputContext = outputContext
                                 }
                                 |> toRuleProjectVisitor
@@ -5488,7 +5488,7 @@ createDependenciesVisitor schema { exceptions } raise cache { allVisitor, direct
                                     Cache.createEntryForProjectFileCache
                                         { contentHash = dependenciesHash
                                         , errors = errors
-                                        , inputContextHash = inputContextHash
+                                        , inputContextHash = [ inputContextHash ]
                                         , outputContext = finalOutputContext
                                         }
                             in

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5666,13 +5666,13 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
             ( initialProjectContextHash, initialProjectContext ) =
                 findInitialInputContext schema.initialProjectContext [ hidden.cache.dependencies, hidden.cache.readme, hidden.cache.elmJson ]
 
+            inputContextHashes : List (ContextHash projectContext)
+            inputContextHashes =
+                computeProjectContextHashes traversalAndFolder project hidden.cache.moduleContexts incoming initialProjectContextHash
+
             inputProjectContext : projectContext
             inputProjectContext =
                 computeProjectContext traversalAndFolder project hidden.cache.moduleContexts incoming initialProjectContext
-
-            inputContextHashes : List (ContextHash projectContext)
-            inputContextHashes =
-                [ ContextHash.create inputProjectContext ]
 
             isFileIgnored : Bool
             isFileIgnored =

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5578,10 +5578,6 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
             Just
                 (\() ->
                     let
-                        inputContext : projectContext
-                        inputContext =
-                            computeFinalContext schema cache
-
                         inputContextHashes : List (ContextHash projectContext)
                         inputContextHashes =
                             computeFinalContextHashes schema cache
@@ -5596,6 +5592,10 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
 
                         Nothing ->
                             let
+                                inputContext : projectContext
+                                inputContext =
+                                    computeFinalContext schema cache
+
                                 errors : List (Error {})
                                 errors =
                                     filterExceptionsAndSetName exceptions schema.name (finalEvaluationFn inputContext)

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5553,9 +5553,9 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
                         inputContext =
                             computeFinalContext schema cache
 
-                        inputContextHashes : ContextHash projectContext
+                        inputContextHashes : List (ContextHash projectContext)
                         inputContextHashes =
-                            ContextHash.create inputContext
+                            [ ContextHash.create inputContext ]
 
                         cachePredicate : FinalProjectEvaluationCache projectContext -> Bool
                         cachePredicate entry =

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5593,13 +5593,12 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
 
                         Nothing ->
                             let
-                                inputContext : projectContext
-                                inputContext =
-                                    computeFinalContext schema cache
-
                                 errors : List (Error {})
                                 errors =
-                                    filterExceptionsAndSetName exceptions schema.name (finalEvaluationFn inputContext)
+                                    cache
+                                        |> computeFinalContext schema
+                                        |> finalEvaluationFn
+                                        |> filterExceptionsAndSetName exceptions schema.name
                             in
                             ( errors
                             , raise { cache | finalEvaluationErrors = Just (Cache.createNoOutput inputContextHashes errors) }

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5553,9 +5553,13 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
                         inputContext =
                             computeFinalContext schema cache
 
+                        inputContextHashes : ContextHash projectContext
+                        inputContextHashes =
+                            ContextHash.create inputContext
+
                         cachePredicate : FinalProjectEvaluationCache projectContext -> Bool
                         cachePredicate entry =
-                            Cache.matchNoOutput (ContextHash.create inputContext) entry
+                            Cache.matchNoOutput inputContextHashes entry
                     in
                     case reuseProjectRuleCache cachePredicate .finalEvaluationErrors cache of
                         Just entry ->
@@ -5568,7 +5572,7 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
                                     filterExceptionsAndSetName exceptions schema.name (finalEvaluationFn inputContext)
                             in
                             ( errors
-                            , raise { cache | finalEvaluationErrors = Just (Cache.createNoOutput (ContextHash.create inputContext) errors) }
+                            , raise { cache | finalEvaluationErrors = Just (Cache.createNoOutput inputContextHashes errors) }
                             )
                 )
 

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -4156,7 +4156,7 @@ type alias FinalProjectEvaluationCache projectContext =
 
 
 type alias ExtractCache projectContext =
-    { inputContext : ContextHash projectContext
+    { inputContextHashes : List (ContextHash projectContext)
     , extract : Extract
     }
 
@@ -5622,13 +5622,13 @@ createDataExtractVisitor schema raise cache =
             \reviewOptions extracts ->
                 if reviewOptions.extract then
                     let
-                        inputContext : projectContext
-                        inputContext =
-                            computeFinalContext schema cache
+                        inputContextHashes : List (ContextHash projectContext)
+                        inputContextHashes =
+                            computeFinalContextHashes schema cache
 
                         cachePredicate : ExtractCache projectContext -> Bool
                         cachePredicate extract =
-                            extract.inputContext == ContextHash.create inputContext
+                            extract.inputContextHashes == inputContextHashes
 
                         ( Extract extractData, newCache ) =
                             case reuseProjectRuleCache cachePredicate .extract cache of
@@ -5637,12 +5637,16 @@ createDataExtractVisitor schema raise cache =
 
                                 Nothing ->
                                     let
+                                        inputContext : projectContext
+                                        inputContext =
+                                            computeFinalContext schema cache
+
                                         extract : Extract
                                         extract =
                                             dataExtractor inputContext
                                     in
                                     ( extract
-                                    , { cache | extract = Just { inputContext = ContextHash.create inputContext, extract = extract } }
+                                    , { cache | extract = Just { inputContextHashes = inputContextHashes, extract = extract } }
                                     )
                     in
                     ( Dict.insert schema.name extractData extracts

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5584,7 +5584,7 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
 
                         inputContextHashes : List (ContextHash projectContext)
                         inputContextHashes =
-                            [ ContextHash.create inputContext ]
+                            computeFinalContextHashes schema cache
 
                         cachePredicate : FinalProjectEvaluationCache projectContext -> Bool
                         cachePredicate entry =

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5648,9 +5648,9 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
             inputProjectContext =
                 computeProjectContext traversalAndFolder project hidden.cache.moduleContexts incoming initialProjectContext
 
-            inputContextHash : ContextHash projectContext
-            inputContextHash =
-                ContextHash.create inputProjectContext
+            inputContextHashes : List (ContextHash projectContext)
+            inputContextHashes =
+                [ ContextHash.create inputProjectContext ]
 
             isFileIgnored : Bool
             isFileIgnored =
@@ -5660,7 +5660,7 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
             shouldReuseCache cacheEntry =
                 Cache.match
                     moduleContentHash
-                    inputContextHash
+                    inputContextHashes
                     cacheEntry
                     { isFileIgnored = isFileIgnored
                     , requestedData = hidden.ruleData.requestedData
@@ -5703,7 +5703,7 @@ createModuleVisitorFromProjectVisitorHelp schema exceptions raise hidden travers
                                         Cache.createModuleEntry
                                             { contentHash = moduleContentHash
                                             , errors = errors
-                                            , inputContextHashes = inputContextHash
+                                            , inputContextHashes = inputContextHashes
                                             , isFileIgnored = isFileIgnored
                                             , outputContext = outputProjectContext
                                             }

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -5568,7 +5568,7 @@ createFinalProjectEvaluationVisitor schema { exceptions } raise cache =
                                     filterExceptionsAndSetName exceptions schema.name (finalEvaluationFn inputContext)
                             in
                             ( errors
-                            , raise { cache | finalEvaluationErrors = Just (Cache.createNoOutput inputContext errors) }
+                            , raise { cache | finalEvaluationErrors = Just (Cache.createNoOutput (ContextHash.create inputContext) errors) }
                             )
                 )
 

--- a/src/Review/Rule.elm
+++ b/src/Review/Rule.elm
@@ -4215,7 +4215,7 @@ finalCacheMarker _ _ cache =
 computeFinalContextHashes : ProjectRuleSchemaData projectContext moduleContext -> ProjectRuleCache projectContext -> List (ContextHash projectContext)
 computeFinalContextHashes schema cache =
     let
-        ( projectContextHash, projectContext ) =
+        ( projectContextHash, _ ) =
             findInitialInputContext schema.initialProjectContext [ cache.dependencies, cache.readme, cache.elmJson ]
 
         traversalAndFolder : TraversalAndFolder projectContext moduleContext
@@ -4244,7 +4244,7 @@ computeFinalContextHashes schema cache =
 computeFinalContext : ProjectRuleSchemaData projectContext moduleContext -> ProjectRuleCache projectContext -> projectContext
 computeFinalContext schema cache =
     let
-        ( projectContextHash, projectContext ) =
+        ( _, projectContext ) =
             findInitialInputContext schema.initialProjectContext [ cache.dependencies, cache.readme, cache.elmJson ]
 
         traversalAndFolder : TraversalAndFolder projectContext moduleContext


### PR DESCRIPTION
## tl;dr

This vastly improves the performance of `elm-review` given a full cache.

On my work codebase, this PR brings the analysis part down **from 15-18 seconds to below 2 seconds** :tada:

## Some context

I was disappointed by how the cache performed in the latest release of `elm-review` (since v2.11.0 for the package and v2.9.0 for the CLI), and I got it to be much, much faster!

On my work project, with an empty cache the analysis part of the process (not the file loading and all that) took somewhere around 35-45 seconds (I'd have to check, but that's the ballpark).
With a full cache and no changes, the analysis part took 15-18 seconds, which is pretty good but not amazing, and the gain were offset a bit by the loading (~3-6 seconds, off the top of my head) and writing of the cache (~2-4 seconds). So all-in-all: worth having but not as great as expected.

This PR now brings this down to below 2 seconds under the same conditions.

## Explanation

The way that we checked that the cache could be reused for a module (or for the final evaluation and data extract) is by comparing the input project context with the one we have in the cache. If they're the same then we can reuse the results and skip the analysis of the file.

The thing is that because the project contexts are very large pieces of data, we don't want to store them as-is in the file-system cache, as that would blow up the file's size (that was my MVP, and some files were 400MB large :sweat_smile:). We stored the "output" project contexts (that is the result of the analysis) as-is though, as we need them to initialize the project context of a module that needs to be analyzed. But the "input" context cache is only necessary to check whether we can re-use the cached results.

So to minimize the space that we use for the input project context, we hash them to transform them into plain numbers/strings (through some JS-hackery: `hash(JSON.stringify(context))`). And this stringification+hashing is actually very costly because of the size of the data.

The way that we construct the input context is by folding all the output project contexts from the imported files. Meaning that any time we want to check whether a file can be skipped, we fold those together and we hash the result, which we then compare with the cache key. Needing to do this quite expensive computation was the reason that the analysis was slow, even with the cache.

So what I ended up doing is to change the cache key: instead of it being the hash of the folded context of all imported modules, the cache key is now the list of hashes for each imported module's output project context. The check is slightly less performant (we now compare 2 lists vs comparing 2 strings/numbers before) but that is nothing compared to hashing the context.

So now instead of combining the project contexts and hashing it, we now only hash the output project context of an entry after we've analyzed it.

This will potentially make the cache slightly more brittle:
1) If a module's output context gets changed after a re-analysis to a new value but that doesn't have an impact on the folded project context, then we will now re-evaluate the module anyway.
2) The order of modules might change from one run to another if the import graph changes slightly, then the order of things might be slightly different). To remedy this, I'm currently sorting the list of hashes. We can probably find a different method (for instance a `Dict ModuleName (ContextHash projectContext)`) but this will do for now.

## Facepalm

The sad thing is that this was the way the cache worked before (when it was only an in-memory check and there was no need to hash anything). And sometime during the process I thought "well, they should be equivalent. Let's switch it so that we only have a single comparison to do" (and it would help with point `1)` above). Big mistake :sweat_smile: