### PR TITLE
Fix let function arguments not registering with the correct module name

### DIFF
--- a/src/Review/ModuleNameLookupTable/Compute.elm
+++ b/src/Review/ModuleNameLookupTable/Compute.elm
@@ -1220,11 +1220,28 @@ expressionEnterVisitor node context =
                         (\declaration scopes ->
                             case Node.value declaration of
                                 Expression.LetFunction function ->
-                                    registerVariable
-                                        { variableType = LetVariable
-                                        , node = (Node.value function.declaration).name
-                                        }
-                                        scopes
+                                    let
+                                        { name, expression, arguments } =
+                                            Node.value function.declaration
+
+                                        withLetVariable : NonEmpty Scope
+                                        withLetVariable =
+                                            registerVariable
+                                                { variableType = LetVariable
+                                                , node = name
+                                                }
+                                                scopes
+                                    in
+                                    if List.isEmpty arguments then
+                                        withLetVariable
+
+                                    else
+                                        let
+                                            names : Dict String VariableInfo
+                                            names =
+                                                collectNamesFromPattern PatternVariable arguments Dict.empty
+                                        in
+                                        NonEmpty.mapHead (\scope -> { scope | cases = ( expression, names ) :: scope.cases }) withLetVariable
 
                                 Expression.LetDestructuring _ _ ->
                                     scopes

--- a/tests/ModuleNameLookupTableTest.elm
+++ b/tests/ModuleNameLookupTableTest.elm
@@ -690,7 +690,7 @@ collectPatterns lookupFunction context node =
             collectPatterns lookupFunction context subPattern
 
         _ ->
-            Debug.todo "Other patterns in case expressions are not handled"
+            Debug.todo ("Other patterns in case expressions are not handled: " ++ Debug.toString node)
 
 
 getRealName : (ModuleNameLookupTable -> Range -> Maybe ModuleName) -> ModuleContext -> ModuleName -> Range -> String -> String

--- a/tests/ModuleNameLookupTableTest.elm
+++ b/tests/ModuleNameLookupTableTest.elm
@@ -93,6 +93,10 @@ a = localValue
  True
  Just
  Cmd.none
+ (let foo get = get
+  in
+  get
+ )
  (+)
  (117 + 3)
  (<?>)
@@ -155,6 +159,8 @@ Http.get -> Http.get
 <nothing>.True -> Basics.True
 <nothing>.Just -> Maybe.Just
 Cmd.none -> Platform.Cmd.none
+<nothing>.get -> <nothing>.get
+<nothing>.get -> Http.get
 <nothing>.+ -> Basics.+
 <nothing>.+ -> Basics.+
 <nothing>.<?> -> Url.Parser.<?>
@@ -688,6 +694,9 @@ collectPatterns lookupFunction context node =
 
         Pattern.AsPattern subPattern _ ->
             collectPatterns lookupFunction context subPattern
+
+        Pattern.VarPattern _ ->
+            []
 
         _ ->
             Debug.todo ("Other patterns in case expressions are not handled: " ++ Debug.toString node)


### PR DESCRIPTION
@r-k-b noticed a bug in the lookup table implementation:

```elm
module A exposing (..)
import B exposing (someValue)

a =
    let
        b someValue =
            someValue <-- This one
    in
    someValue
```

The module name for the `someValue` tagged above (inside the body of `b`) was resolved a `[ "B" ]`, which is incorrect and should be `[]`, as the parameter name shadows the import.

This PR fixes the issue by correctly considering let functions to have a scope with their own variable bindings.